### PR TITLE
fix: use `getCurrentGitRef`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from 'c12'
-import { getLastGitTag, getCurrentGitBranch } from './git'
+import { getLastGitTag, getCurrentGitRef } from './git'
 
 export interface ChangelogConfig {
   types: Record<string, { title: string}>
@@ -43,7 +43,7 @@ export async function loadChangelogConfig (cwd: string, overrides?: Partial<Chan
   }
 
   if (!config.to) {
-    config.to = await getCurrentGitBranch()
+    config.to = await getCurrentGitRef()
   }
 
   return config

--- a/src/git.ts
+++ b/src/git.ts
@@ -27,8 +27,15 @@ export async function getLastGitTag () {
 }
 
 export async function getCurrentGitBranch () {
-  const r = await execCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
-  return r
+  return await execCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+}
+
+export async function getCurrentGitTag () {
+  return await execCommand('git', ['tag', '--points-at', 'HEAD'])
+}
+
+export async function getCurrentGitRef () {
+  return await getCurrentGitTag() || await getCurrentGitBranch()
 }
 
 export async function getGitDiff (from, to): Promise<RawGitCommit[]> {


### PR DESCRIPTION
When you on a tag, `getCurrentGitBranch` failed to grab the tag name and results `to` to be `HEAD`

```bash
changelogen on  tags/v0.1.0 is 📦 v0.1.0 via ⬢ v16.14.2 
➜ git checkout tags/v0.1.0       
HEAD is now at 79d6a90 chore(release): 0.1.0

changelogen on  tags/v0.1.0 is 📦 v0.1.0 via ⬢ v16.14.2 
➜ git rev-parse --abbrev-ref HEAD
HEAD

changelogen on  tags/v0.1.0 is 📦 v0.1.0 via ⬢ v16.14.2 
➜ git tag --points-at HEAD 
v0.1.0
```