### PR TITLE
fix: let `--output` work without value

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface ChangelogConfig {
   from: string
   to: string
   newVersion?: string
-  output: string | false
+  output: string | boolean
 }
 
 const ConfigDefaults: ChangelogConfig = {
@@ -59,7 +59,7 @@ export async function loadChangelogConfig (cwd: string, overrides?: Partial<Chan
   if (!config.output) {
     config.output = false
   } else if (config.output) {
-    config.output = resolve(cwd, config.output)
+    config.output = config.output === true ? ConfigDefaults.output : resolve(cwd, config.output)
   }
 
   return config


### PR DESCRIPTION
I expect to generate only *CHANGELOG.md* which is defaults by below:
```sh
npx changelogen@latest --output
```

Actually, it throws error since `--output` is `true` but `CHANGELOG.md`.

As workaround, I use `npx changelogen@latest --output > xxx.md` for my purpose.

Would it be more appropriate to set  `--output` 's true to `CHANGELOG.md`?