### PR TITLE
feat!: resolve github usernames using `ungh/ungh`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "convert-gitmoji": "^0.1.2",
     "execa": "^6.1.0",
     "mri": "^1.2.0",
+    "node-fetch-native": "^0.1.8",
     "pkg-types": "^0.3.5",
     "scule": "^0.3.2",
     "semver": "^7.3.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ specifiers:
   execa: ^6.1.0
   jiti: ^1.16.0
   mri: ^1.2.0
+  node-fetch-native: ^0.1.8
   pkg-types: ^0.3.5
   scule: ^0.3.2
   semver: ^7.3.8
@@ -26,6 +27,7 @@ dependencies:
   convert-gitmoji: 0.1.2
   execa: 6.1.0
   mri: 1.2.0
+  node-fetch-native: 0.1.8
   pkg-types: 0.3.5
   scule: 0.3.2
   semver: 7.3.8
@@ -3222,6 +3224,10 @@ packages:
   /neo-async/2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
+
+  /node-fetch-native/0.1.8:
+    resolution: {integrity: sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q==}
+    dev: false
 
   /node-releases/2.0.4:
     resolution: {integrity: sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ async function main () {
   }
 
   // Generate markdown
-  const markdown = generateMarkDown(commits, config)
+  const markdown = await generateMarkDown(commits, config)
 
   // Show changelog in CLI unless bumping or releasing
   const displayOnly = !args.bump && !args.release

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -56,20 +56,18 @@ export async function generateMarkDown (commits: GitCommit[], config: ChangelogC
   }
 
   // Try to map authors to github usernames
-  if (config.github) {
-    await Promise.all(Array.from(_authors.keys()).map(async (authorName) => {
-      const meta = _authors.get(authorName)
-      for (const email of meta.email) {
-        const { user } = await fetch(`https://ungh.unjs.io/user/find/${email}`)
-          .then(r => r.json())
-          .catch(() => ({ user: null }))
-        if (user) {
-          meta.github = user.username
-          break
-        }
+  await Promise.all(Array.from(_authors.keys()).map(async (authorName) => {
+    const meta = _authors.get(authorName)
+    for (const email of meta.email) {
+      const { user } = await fetch(`https://ungh.unjs.io/user/find/${email}`)
+        .then(r => r.json())
+        .catch(() => ({ user: null }))
+      if (user) {
+        meta.github = user.username
+        break
       }
-    }))
-  }
+    }
+  }))
 
   const authors = Array.from(_authors.entries()).map(e => ({ name: e[0], ...e[1] }))
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,9 +1,10 @@
 import { upperFirst } from 'scule'
 import { convert } from 'convert-gitmoji'
+import { fetch } from 'node-fetch-native'
 import type { ChangelogConfig } from './config'
 import type { GitCommit, Reference } from './git'
 
-export function generateMarkDown (commits: GitCommit[], config: ChangelogConfig) {
+export async function generateMarkDown (commits: GitCommit[], config: ChangelogConfig) {
   const typeGroups = groupBy(commits, 'type')
 
   const markdown: string[] = []
@@ -42,13 +43,45 @@ export function generateMarkDown (commits: GitCommit[], config: ChangelogConfig)
     )
   }
 
-  let authors = commits.flatMap(commit => commit.authors.map(author => formatName(author.name)))
-  authors = uniq(authors).sort()
+  const _authors = new Map<string, { email: Set<string>, github?: string }>()
+  for (const commit of commits) {
+    if (commit.author) {
+      if (!_authors.has(commit.author.name)) {
+        _authors.set(commit.author.name, { email: new Set([commit.author.email]) })
+      } else {
+        const entry = _authors.get(commit.author.name)
+        entry.email.add(commit.author.email)
+      }
+    }
+  }
+
+  // Try to map authors to github usernames
+  if (config.github) {
+    await Promise.all(Array.from(_authors.keys()).map(async (authorName) => {
+      const meta = _authors.get(authorName)
+      for (const email of meta.email) {
+        const { user } = await fetch(`https://ungh.unjs.io/user/find/${email}`)
+          .then(r => r.json())
+          .catch(() => ({ user: null }))
+        if (user) {
+          meta.github = user.username
+          break
+        }
+      }
+    }))
+  }
+
+  const authors = Array.from(_authors.entries()).map(e => ({ name: e[0], ...e[1] }))
 
   if (authors.length) {
     markdown.push(
       '', '### ' + '❤️  Contributors', '',
-      ...authors.map(name => '- ' + name)
+      ...authors.map((i) => {
+        const name = formatName(i.name)
+        const email = i.email.size ? `<${Array.from(i.email)[0]}>` : ''
+        const github = i.github ? `([@${i.github}](http://github.com/${i.github}))` : ''
+        return `- ${name} ${github || email}`
+      })
     )
   }
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -112,7 +112,7 @@ describe('git', () => {
       ]
     `)
 
-    const md = generateMarkDown(parsed, config)
+    const md = await generateMarkDown(parsed, config)
 
     expect(md).toMatchInlineSnapshot(`
       "## 31a08615bb7da611dcaefe33b510d23aa7d2cc29...27440655a169c2f462d891d2f243db54c174f6b7


### PR DESCRIPTION
Automatically try to resolve usernames using [`unjs/ungh`](https://github.com/unjs/ungh) without any token! 

There is a slightly breaking change that `generateMarkDown` is now async.