### PR TITLE
fix: only access latest tag accessible from current branch

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -27,11 +27,9 @@ export interface GitCommit extends RawGitCommit {
 }
 
 export async function getLastGitTag() {
-  const r = await execCommand("git", [
-    "describe",
-    "--tags",
-    "--abbrev=0",
-  ]).then((r) => r.split("\n"));
+  const r = await execCommand("git", ["describe", "--tags", "--abbrev=0"]).then(
+    (r) => r.split("\n")
+  );
   return r[r.length - 1];
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -28,10 +28,9 @@ export interface GitCommit extends RawGitCommit {
 
 export async function getLastGitTag() {
   const r = await execCommand("git", [
-    "--no-pager",
-    "tag",
-    "-l",
-    "--sort=creatordate",
+    "describe",
+    "--tags",
+    "--abbrev=0",
   ]).then((r) => r.split("\n"));
   return r[r.length - 1];
 }


### PR DESCRIPTION
On Nuxt framework repo, for example, we have multiple branches. `2.x` branch continues having new tags, but these are irrelevant for `main` branch. This updates git command to use only the latest accessible tag.