### PR TITLE
feat: monorepo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,55 @@ By default in unauthenticated mode, changelogen will open a browser link to make
 
 ## Configuration
 
-Configuration is loaded by [unjs/c12](https://github.com/unjs/c12) from cwd. You can use either `changelog.json`, `changelog.{ts,js,mjs,cjs}`, `.changelogrc` or use the `changelog` field in `package.json`.
+Configuration is loaded by [unjs/c12](https://github.com/unjs/c12) from cwd. You can use either `changelog.config.json`, `changelog.config.{ts,js,mjs,cjs}`, `.changelogrc` or use the `changelog` field in `package.json`.
 
 See [./src/config.ts](./src/config.ts) for available options and defaults.
+
+### Monorepo
+
+To support a monorepo, you can set `monorepo: true` in the config. This will scan packages using [@manypkg/get-packages](https://github.com/Thinkmill/manypkg/tree/main/packages/get-packages) and generate a CHANGELOG.md file in every package directory.
+
+```ts
+export default {
+    monorepo: true,
+}
+```
+
+If you don't want to use the entire package, you can specify the package name(s) in the `monorepo.filter`.
+
+```ts
+export default {
+    monorepo: {
+        filter: [
+            'awesome-pkg',
+            '@awesome-pkg/shared',
+        ],
+    },
+}
+```
+
+If you want to change the order in which packages are applied, you can set `monorepo.sort` and pass in the compareFn (just like using [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#parameters)).
+
+
+```ts
+export default {
+    monorepo: {
+        sort: (pkgA: Package, pkgB: Package) => {
+            return pkgA.packageJson.name - pkgB.packageJson.name
+        },
+    }
+}
+```
+
+### Configure git commit message / tag message / tag body
+
+You can freely specify the content of the git commit message, git tag message, and tag body, with the default value being available in [./src/config.ts](./src/config.ts).
+
+The following variables are supported:
+
+- `NEW_VERSION`: the new version number (e.g. `1.0.0`)
+- `PACKAGE_NAME`: the current package name (only available if monorepo is set)
+- `PACKAGE_DIR`: the current package directory (only available if monorepo is set)
 
 ## 💻 Development
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "test": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {
+    "@manypkg/get-packages": "^2.1.0",
     "c12": "^1.2.0",
     "colorette": "^2.0.19",
     "consola": "^2.15.3",
     "convert-gitmoji": "^0.1.3",
+    "defu": "^6.1.2",
     "execa": "^7.1.1",
     "mri": "^1.2.0",
     "node-fetch-native": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@manypkg/get-packages': ^2.1.0
   '@types/node': ^18.15.5
   '@types/semver': ^7.3.13
   '@vitest/coverage-c8': ^0.29.7
@@ -8,6 +9,7 @@ specifiers:
   colorette: ^2.0.19
   consola: ^2.15.3
   convert-gitmoji: ^0.1.3
+  defu: ^6.1.2
   eslint: ^8.36.0
   eslint-config-unjs: ^0.1.0
   execa: ^7.1.1
@@ -28,10 +30,12 @@ specifiers:
   yaml: ^2.2.1
 
 dependencies:
+  '@manypkg/get-packages': 2.1.0
   c12: 1.2.0
   colorette: 2.0.19
   consola: 2.15.3
   convert-gitmoji: 0.1.3
+  defu: 6.1.2
   execa: 7.1.1
   mri: 1.2.0
   node-fetch-native: 1.0.2
@@ -770,18 +774,44 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
+  /@manypkg/find-root/2.1.0:
+    resolution: {integrity: sha512-NEYRVlZCJYhRTqQURhv+WBpDcvmsp/M423Wcdvggv8lYJYD4GtqnTMLrQaTjA10fYt/PIc3tSdwV+wxJnWqPfQ==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      '@manypkg/tools': 1.0.0
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+    dev: false
+
+  /@manypkg/get-packages/2.1.0:
+    resolution: {integrity: sha512-IgWPEGgeKeR3ISlgHAMbY+m042yjNe3NPt8UmJT0xMwofe/UifUVtOq5aUBkNSygfOrcUh/j5JExLPuOx72quA==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      '@manypkg/find-root': 2.1.0
+      '@manypkg/tools': 1.0.0
+    dev: false
+
+  /@manypkg/tools/1.0.0:
+    resolution: {integrity: sha512-W8uDMhDGtwNyXYr6A+MWggxdL3spOQ8rfMNYpNph1GDJ0v084MnBFdpF1jvcPZ0okHAeYccV7le8AUs+fzwsAQ==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      jju: 1.4.0
+      read-yaml-file: 1.1.0
+    dev: false
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: true
 
   /@nodelib/fs.stat/2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: true
 
   /@nodelib/fs.walk/1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -789,7 +819,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
-    dev: true
 
   /@pkgr/utils/2.3.1:
     resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
@@ -923,6 +952,10 @@ packages:
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
+
+  /@types/node/12.20.55:
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+    dev: false
 
   /@types/node/18.15.5:
     resolution: {integrity: sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==}
@@ -1193,6 +1226,12 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /argparse/1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: false
+
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
@@ -1215,7 +1254,6 @@ packages:
   /array-union/2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-    dev: true
 
   /array.prototype.flat/1.3.1:
     resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==}
@@ -1273,7 +1311,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /browserslist/4.21.4:
     resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
@@ -1779,7 +1816,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
-    dev: true
 
   /doctrine/2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2314,6 +2350,12 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /esprima/4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
   /esquery/1.4.2:
     resolution: {integrity: sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==}
     engines: {node: '>=0.10'}
@@ -2375,7 +2417,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: true
 
   /fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -2389,7 +2430,6 @@ packages:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
-    dev: true
 
   /figures/3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -2410,7 +2450,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /find-up/2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
@@ -2432,7 +2471,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: true
 
   /find-up/5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2481,6 +2519,15 @@ packages:
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
+
+  /fs-extra/8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+    dev: false
 
   /fs-minipass/2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -2624,7 +2671,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob-parent/6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2688,7 +2734,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
 
   /globby/13.1.3:
     resolution: {integrity: sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==}
@@ -2713,7 +2758,6 @@ packages:
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: true
 
   /grapheme-splitter/1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
@@ -2818,7 +2862,6 @@ packages:
   /ignore/5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
-    dev: true
 
   /import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -2921,7 +2964,6 @@ packages:
   /is-extglob/2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -2938,7 +2980,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-module/1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
@@ -2959,7 +3000,6 @@ packages:
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-obj/2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
@@ -3078,6 +3118,10 @@ packages:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
 
+  /jju/1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    dev: false
+
   /js-sdsl/4.3.0:
     resolution: {integrity: sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==}
     dev: true
@@ -3085,6 +3129,14 @@ packages:
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: true
+
+  /js-yaml/3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: false
 
   /js-yaml/4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -3134,6 +3186,12 @@ packages:
 
   /jsonc-parser/3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+
+  /jsonfile/4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    optionalDependencies:
+      graceful-fs: 4.2.10
+    dev: false
 
   /jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -3201,7 +3259,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
-    dev: true
 
   /locate-path/6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -3295,7 +3352,6 @@ packages:
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-    dev: true
 
   /micromatch/4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -3303,7 +3359,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
   /mimic-fn/4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -3556,7 +3611,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
-    dev: true
 
   /p-limit/3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -3591,7 +3645,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
-    dev: true
 
   /p-locate/5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -3608,7 +3661,6 @@ packages:
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /parent-module/1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3643,7 +3695,6 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -3673,7 +3724,6 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /pathe/1.1.0:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
@@ -3689,7 +3739,6 @@ packages:
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /pify/2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -3700,6 +3749,11 @@ packages:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
     dev: true
+
+  /pify/4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+    dev: false
 
   /pkg-types/1.0.2:
     resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
@@ -3763,7 +3817,6 @@ packages:
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
 
   /quick-lru/4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -3817,6 +3870,16 @@ packages:
       parse-json: 5.2.0
       type-fest: 0.6.0
     dev: true
+
+  /read-yaml-file/1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
+    dependencies:
+      graceful-fs: 4.2.10
+      js-yaml: 3.14.1
+      pify: 4.0.1
+      strip-bom: 3.0.0
+    dev: false
 
   /readable-stream/2.3.7:
     resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
@@ -3888,7 +3951,6 @@ packages:
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
 
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -3923,7 +3985,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: true
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -3995,7 +4056,6 @@ packages:
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /slash/4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
@@ -4053,6 +4113,10 @@ packages:
     dependencies:
       readable-stream: 3.6.0
     dev: true
+
+  /sprintf-js/1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: false
 
   /stackback/0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4151,7 +4215,6 @@ packages:
   /strip-bom/3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-    dev: true
 
   /strip-final-newline/3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -4286,7 +4349,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
@@ -4423,6 +4485,11 @@ packages:
       - sass
       - supports-color
     dev: true
+
+  /universalify/0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+    dev: false
 
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -43,14 +43,25 @@ export async function writeChangelog(
   await writeFile(targetPath, content);
 }
 
-export function getChangelogPath(config: ChangelogConfig, pkg?: Package) {
+export function getChangelogPath(
+  config: ChangelogConfig,
+  pkg?: Package,
+  relative = false
+) {
   if (config.output === false) {
     return;
   }
 
-  const rawPath = format(
-    config.output as string,
-    getTemplateParams(config, pkg)
-  );
+  const params = getTemplateParams(config, pkg);
+  if (relative) {
+    params.PACKAGE_DIR = pkg.relativeDir;
+  }
+
+  const rawPath = format(config.output as string, params);
+
+  if (relative) {
+    return rawPath;
+  }
+
   return resolve(rawPath);
 }

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,0 +1,56 @@
+import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { Package } from "@manypkg/get-packages";
+import consola from "consola";
+import { ChangelogConfig } from "./config";
+import { format, getTemplateParams } from "./utils/template";
+
+const lastEntryRE = /^###?\s+.*$/m;
+
+export async function writeChangelog(
+  config: ChangelogConfig,
+  markdown: string,
+  pkg?: Package
+) {
+  const targetPath = getChangelogPath(config, pkg);
+  if (!targetPath) {
+    return;
+  }
+  const shortPath = targetPath.replace(process.cwd(), "");
+  let content: string;
+
+  if (existsSync(targetPath)) {
+    consola.info(`Updating ${shortPath}`);
+    content = await readFile(targetPath, "utf8");
+  } else {
+    consola.info(`Creating ${shortPath}`);
+    content = "# Changelog\n\n";
+  }
+
+  const lastEntry = content.match(lastEntryRE);
+
+  if (lastEntry) {
+    content =
+      content.slice(0, lastEntry.index) +
+      markdown +
+      "\n\n" +
+      content.slice(lastEntry.index);
+  } else {
+    content += "\n" + markdown + "\n\n";
+  }
+
+  await writeFile(targetPath, content);
+}
+
+export function getChangelogPath(config: ChangelogConfig, pkg?: Package) {
+  if (config.output === false) {
+    return;
+  }
+
+  const rawPath = format(
+    config.output as string,
+    getTemplateParams(config, pkg)
+  );
+  return resolve(rawPath);
+}

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -1,15 +1,26 @@
-import { existsSync, promises as fsp } from "node:fs";
 import type { Argv } from "mri";
 import { resolve } from "pathe";
 import consola from "consola";
 import { execa } from "execa";
+import { Package } from "@manypkg/get-packages";
 import {
   loadChangelogConfig,
   getGitDiff,
   parseCommits,
   bumpVersion,
   generateMarkDown,
+  ChangelogConfig,
+  GitCommit,
+  getLastGitTag,
 } from "..";
+import { getSubPackages } from "../monorepo";
+import {
+  getTagBody,
+  getTagMessage,
+  getTagMessageWithAnyVersion,
+} from "../git-tag";
+import { getCommitFiles, getCommitMessage } from "../git-commit";
+import { writeChangelog } from "../changelog";
 import { githubRelease } from "./github";
 
 export default async function defaultMain(args: Argv) {
@@ -25,9 +36,58 @@ export default async function defaultMain(args: Argv) {
   });
 
   const logger = consola.create({ stdout: process.stderr });
-  logger.info(`Generating changelog for ${config.from || ""}...${config.to}`);
 
-  const rawCommits = await getGitDiff(config.from, config.to);
+  if (config.monorepo) {
+    const packages = await getSubPackages(config);
+    for (const pkg of packages) {
+      const originCwd = config.cwd;
+      const originFrom = config.from;
+      const originNewVersion = config.newVersion;
+
+      const pkgDir = pkg.dir;
+      const pkgName = pkg.packageJson.name;
+
+      config.cwd = pkgDir;
+      config.from = await getLastGitTag(
+        getTagMessageWithAnyVersion(config, pkg)
+      );
+
+      logger.info(
+        `Generating changelog for ${config.from || ""}...${config.to}`
+      );
+
+      const commits = await getCommits(config, config.from, config.to);
+      if (commits.length === 0) {
+        logger.warn(`Package "${pkgName}" is not change`);
+        continue;
+      }
+
+      await execBumpVersion(args, config, commits);
+      const markdown = await generateMarkDown(commits, config);
+      await genChangelog(args, config, markdown, pkg);
+      await execRelease(args, config, markdown, pkg);
+
+      config.cwd = originCwd;
+      config.from = originFrom;
+      config.newVersion = originNewVersion;
+    }
+  } else {
+    logger.info(`Generating changelog for ${config.from || ""}...${config.to}`);
+
+    const commits = await getCommits(config, config.from, config.to);
+    await execBumpVersion(args, config, commits, true);
+    const markdown = await generateMarkDown(commits, config);
+    await genChangelog(args, config, markdown);
+    await execRelease(args, config, markdown);
+  }
+}
+
+async function getCommits(
+  config: ChangelogConfig,
+  from: string = config.from,
+  to: string = config.to
+) {
+  const rawCommits = await getGitDiff(from, to, config.cwd);
 
   // Parse commits as conventional commits
   const commits = parseCommits(rawCommits, config).filter(
@@ -36,7 +96,15 @@ export default async function defaultMain(args: Argv) {
       !(c.type === "chore" && c.scope === "deps" && !c.isBreaking)
   );
 
-  // Bump version optionally
+  return commits;
+}
+
+async function execBumpVersion(
+  args: Argv,
+  config: ChangelogConfig,
+  commits: GitCommit[],
+  strict = false
+) {
   if (args.bump || args.release) {
     let type;
     if (args.major) {
@@ -48,15 +116,22 @@ export default async function defaultMain(args: Argv) {
     }
     const newVersion = await bumpVersion(commits, config, { type });
     if (!newVersion) {
-      consola.error("Unable to bump version based on changes.");
-      process.exit(1);
+      if (strict) {
+        consola.error("Unable to bump version based on changes.");
+        process.exit(1);
+      }
+      return;
     }
     config.newVersion = newVersion;
   }
+}
 
-  // Generate markdown
-  const markdown = await generateMarkDown(commits, config);
-
+async function genChangelog(
+  args: Argv,
+  config: ChangelogConfig,
+  markdown: string,
+  pkg?: Package
+) {
   // Show changelog in CLI unless bumping or releasing
   const displayOnly = !args.bump && !args.release;
   if (displayOnly) {
@@ -65,52 +140,32 @@ export default async function defaultMain(args: Argv) {
 
   // Update changelog file (only when bumping or releasing or when --output is specified as a file)
   if (typeof config.output === "string" && (args.output || !displayOnly)) {
-    let changelogMD: string;
-    if (existsSync(config.output)) {
-      consola.info(`Updating ${config.output}`);
-      changelogMD = await fsp.readFile(config.output, "utf8");
-    } else {
-      consola.info(`Creating  ${config.output}`);
-      changelogMD = "# Changelog\n\n";
-    }
-
-    const lastEntry = changelogMD.match(/^###?\s+.*$/m);
-
-    if (lastEntry) {
-      changelogMD =
-        changelogMD.slice(0, lastEntry.index) +
-        markdown +
-        "\n\n" +
-        changelogMD.slice(lastEntry.index);
-    } else {
-      changelogMD += "\n" + markdown + "\n\n";
-    }
-
-    await fsp.writeFile(config.output, changelogMD);
+    await writeChangelog(config, markdown, pkg);
   }
+}
 
+async function execRelease(
+  args: Argv,
+  config: ChangelogConfig,
+  markdown: string,
+  pkg?: Package
+) {
   // Commit and tag changes for release mode
   if (args.release) {
     if (args.commit !== false) {
-      const filesToAdd = [config.output, "package.json"].filter(
-        (f) => f && typeof f === "string"
-      ) as string[];
-      await execa("git", ["add", ...filesToAdd], { cwd });
-      await execa(
-        "git",
-        ["commit", "-m", `chore(release): v${config.newVersion}`],
-        { cwd }
-      );
+      const filesToAdd = getCommitFiles(config, pkg);
+      await execa("git", ["add", ...filesToAdd], { cwd: config.cwd });
+
+      const message = getCommitMessage(config, pkg);
+      await execa("git", ["commit", "-m", message], { cwd: config.cwd });
     }
     if (args.tag !== false) {
-      await execa(
-        "git",
-        ["tag", "-am", "v" + config.newVersion, "v" + config.newVersion],
-        { cwd }
-      );
+      const message = getTagMessage(config, pkg);
+      const body = getTagBody(config, pkg);
+      await execa("git", ["tag", message, "-am", body], { cwd: config.cwd });
     }
     if (args.push === true) {
-      await execa("git", ["push", "--follow-tags"], { cwd });
+      await execa("git", ["push", "--follow-tags"], { cwd: config.cwd });
     }
     if (args.github !== false && config.repo?.provider === "github") {
       await githubRelease(config, {

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -168,10 +168,14 @@ async function execRelease(
       await execa("git", ["push", "--follow-tags"], { cwd: config.cwd });
     }
     if (args.github !== false && config.repo?.provider === "github") {
-      await githubRelease(config, {
-        version: config.newVersion,
-        body: markdown.split("\n").slice(2).join("\n"),
-      });
+      await githubRelease(
+        config,
+        {
+          version: config.newVersion,
+          body: markdown.split("\n").slice(2).join("\n"),
+        },
+        pkg
+      );
     }
   }
 }

--- a/src/git-commit.ts
+++ b/src/git-commit.ts
@@ -1,0 +1,23 @@
+import { resolve } from "node:path";
+import { Package } from "@manypkg/get-packages";
+import { ChangelogConfig } from "./config";
+import { format, getTemplateParams } from "./utils/template";
+import { getChangelogPath } from "./changelog";
+
+export interface GitCommitConfig {
+  message: string;
+}
+
+export function getCommitMessage(
+  config: ChangelogConfig,
+  pkg?: Package
+): string {
+  return format(config.commit.message, getTemplateParams(config, pkg));
+}
+
+export function getCommitFiles(config: ChangelogConfig, pkg?: Package) {
+  const changelogPath = getChangelogPath(config, pkg);
+  const packagePath = resolve(pkg?.dir ?? config.cwd, "package.json");
+
+  return [changelogPath, packagePath].filter((f) => f && typeof f === "string");
+}

--- a/src/git-tag.ts
+++ b/src/git-tag.ts
@@ -1,0 +1,26 @@
+import { Package } from "@manypkg/get-packages";
+import { ChangelogConfig } from "./config";
+import { format, getTemplateParams } from "./utils/template";
+
+export interface GitTagConfig {
+  message: string;
+  body: string;
+}
+
+export function getTagMessage(config: ChangelogConfig, pkg?: Package): string {
+  return format(config.tag.message, getTemplateParams(config, pkg));
+}
+
+export function getTagMessageWithAnyVersion(
+  config: ChangelogConfig,
+  pkg?: Package
+) {
+  return format(config.tag.message, {
+    ...getTemplateParams(config, pkg),
+    NEW_VERSION: "*",
+  });
+}
+
+export function getTagBody(config: ChangelogConfig, pkg?: Package) {
+  return format(config.tag.body, getTemplateParams(config, pkg));
+}

--- a/src/git-tag.ts
+++ b/src/git-tag.ts
@@ -21,6 +21,17 @@ export function getTagMessageWithAnyVersion(
   });
 }
 
+export function getTagMessageWithVersion(
+  config: ChangelogConfig,
+  version: string,
+  pkg?: Package
+) {
+  return format(config.tag.message, {
+    ...getTemplateParams(config, pkg),
+    NEW_VERSION: version,
+  });
+}
+
 export function getTagBody(config: ChangelogConfig, pkg?: Package) {
   return format(config.tag.body, getTemplateParams(config, pkg));
 }

--- a/src/monorepo.ts
+++ b/src/monorepo.ts
@@ -1,0 +1,32 @@
+import { getPackages, Package } from "@manypkg/get-packages";
+import { ChangelogConfig } from "./config";
+
+export interface MonorepoConfig {
+  filter?: string[];
+  sort?: (pkg: Package) => number;
+}
+
+export async function getSubPackages(config: ChangelogConfig) {
+  const { monorepo, cwd } = config;
+  if (!monorepo) {
+    return;
+  }
+
+  const pkgs = await getPackages(cwd);
+  let result = pkgs.packages;
+
+  result = result.filter((item) => item.packageJson.private !== true);
+
+  if (typeof monorepo === "object" && monorepo != null) {
+    if (monorepo.filter) {
+      result = result.filter((item) =>
+        monorepo.filter.includes(item.packageJson.name)
+      );
+    }
+    if (monorepo.sort) {
+      result.sort(monorepo.sort);
+    }
+  }
+
+  return result;
+}

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -1,0 +1,26 @@
+import { Package } from "@manypkg/get-packages";
+import { ChangelogConfig } from "../config";
+
+export type TemplateParamKeys = "NEW_VERSION" | "PACKAGE_NAME" | "PACKAGE_DIR";
+
+export function format(
+  template: string,
+  params: Partial<Record<TemplateParamKeys, string>>
+): string {
+  let str = template;
+  for (const [key, value] of Object.entries(params)) {
+    str = str.replace(`%${key}%`, value);
+  }
+  return str;
+}
+
+export function getTemplateParams(
+  config: ChangelogConfig,
+  pkg?: Package
+): Partial<Record<TemplateParamKeys, string>> {
+  return {
+    NEW_VERSION: config.newVersion ?? pkg?.packageJson.version,
+    PACKAGE_NAME: pkg?.packageJson.name,
+    PACKAGE_DIR: pkg?.dir,
+  };
+}


### PR DESCRIPTION
Making changelogen support monorepo. Although there is another PR (#45) that does the same thing, it doesn't seem to be maintained anymore.

Under monorepo mode, the following will be done:

- Search for all packages
- Generate tags for each package (e.g. `@awesome/pkg@1.0.0`) and get the commits for that package
- If there are no commits, do nothing
- If `--bump` or `--release` is set, update the version of each package
- Generate a CHANGELOG.md file in each package directory.

I think this cloud be resolve #18, config for commit can resolve #82