### PR TITLE
fix: load config from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ By default in unauthenticated mode, changelogen will open a browser link to make
 
 ## Configuration
 
-Configuration is loaded by [unjs/c12](https://github.com/unjs/c12) from cwd. You can use either `changelog.json`, `changelog.{ts,js,mjs,cjs}`, `.changelogrc` or use the `changelog` field in `package.json`.
+Configuration is loaded by [unjs/c12](https://github.com/unjs/c12) from cwd. You can use either `changelog.config.json`, `changelog.config.{ts,js,mjs,cjs}`, `.changelogrc` or use the `changelog` field in `package.json`.
 
 See [./src/config.ts](./src/config.ts) for available options and defaults.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,7 @@ export async function loadChangelogConfig(
   const { config } = await loadConfig<ChangelogConfig>({
     cwd,
     name: "changelog",
+    packageJson: true,
     defaults,
     overrides: {
       cwd,


### PR DESCRIPTION
Load config from package.json file is disabled by default in unjs/c12.

Also fixed configs paths in the README from changelog.* to changelog.config.*