### PR TITLE
feat: add param to require clean working dir (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npx changelogen@latest [...args] [--dir <dir>]
 - `--from`: Start commit reference. When not provided, **latest git tag** will be used as default.
 - `--to`: End commit reference. When not provided, **latest commit in HEAD** will be used as default.
 - `--dir`: Path to git repository. When not provided, **current working directory** will be used as as default.
+- `--clean`: Determine if the working directory is clean and if it is not clean, exit.
 - `--output`: Changelog file name to create or update. Defaults to `CHANGELOG.md` and resolved relative to dir. Use `--no-output` to write to console only.
 - `--bump`: Determine semver change and update version in `package.json`.
 - `--release`. Bumps version in `package.json` and creates commit and git tags using local `git`. You can disable commit using `--no-commit` and tag using `--no-tag`. You can enable the automatic push of the new tag and release commit to your git repository by adding `--push`.

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -6,6 +6,7 @@ import { execa } from "execa";
 import {
   loadChangelogConfig,
   getGitDiff,
+  getCurrentGitStatus,
   parseCommits,
   bumpVersion,
   generateMarkDown,
@@ -25,6 +26,14 @@ export default async function defaultMain(args: Argv) {
     output: args.output,
     newVersion: typeof args.r === "string" ? args.r : undefined,
   });
+
+  if (args.clean) {
+    const dirty = await getCurrentGitStatus();
+    if (dirty) {
+      consola.error("Working directory is not clean.");
+      process.exit(1);
+    }
+  }
 
   const logger = consola.create({ stdout: process.stderr });
   logger.info(`Generating changelog for ${config.from || ""}...${config.to}`);

--- a/src/git.ts
+++ b/src/git.ts
@@ -55,6 +55,10 @@ export async function getGitRemoteURL(cwd: string, remote = "origin") {
   ]);
 }
 
+export async function getCurrentGitStatus() {
+  return await execCommand("git", ["status", "--porcelain"]);
+}
+
 export async function getGitDiff(
   from: string | undefined,
   to = "HEAD"


### PR DESCRIPTION
Adds a `--clean` parameter.  When specified, checks the working directory and exits if it is not clean.