### PR TITLE
feat: add excludeAuthors option (#58)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export interface ChangelogConfig {
     tagMessage?: string;
     tagBody?: string;
   };
+  excludeAuthors: string[];
 }
 
 const getDefaultConfig = () =>
@@ -64,6 +65,7 @@ const getDefaultConfig = () =>
       tagMessage: "v{{newVersion}}",
       tagBody: "v{{newVersion}}",
     },
+    excludeAuthors: [],
   };
 
 export async function loadChangelogConfig(

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -51,6 +51,14 @@ export async function generateMarkDown(
     if (!name || name.includes("[bot]")) {
       continue;
     }
+    if (
+      config.excludeAuthors &&
+      config.excludeAuthors.some(
+        (v) => name.includes(v) || commit.author.email?.includes(v)
+      )
+    ) {
+      continue;
+    }
     if (_authors.has(name)) {
       const entry = _authors.get(name);
       entry.email.add(commit.author.email);


### PR DESCRIPTION
Checks for any of the strings in name or email to exclude them from authors.

Also, can disable contributors section with `excludeAuthors: ['']`

Closes #58 