### PR TITLE
feat: getLastGitTag with pattern

### DIFF
--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -11,6 +11,7 @@ import {
   generateMarkDown,
   BumpVersionOptions,
 } from "..";
+import { getCommitMessage, getTagBody, getTagMessage } from "../template";
 import { githubRelease } from "./github";
 
 export default async function defaultMain(args: Argv) {
@@ -90,21 +91,12 @@ export default async function defaultMain(args: Argv) {
         (f) => f && typeof f === "string"
       ) as string[];
       await execa("git", ["add", ...filesToAdd], { cwd });
-      const msg = config.templates.commitMessage.replaceAll(
-        "{{newVersion}}",
-        config.newVersion
-      );
+      const msg = getCommitMessage(config)
       await execa("git", ["commit", "-m", msg], { cwd });
     }
     if (args.tag !== false) {
-      const msg = config.templates.tagMessage.replaceAll(
-        "{{newVersion}}",
-        config.newVersion
-      );
-      const body = config.templates.tagBody.replaceAll(
-        "{{newVersion}}",
-        config.newVersion
-      );
+      const msg = getTagMessage(config)
+      const body = getTagBody(config)
       await execa("git", ["tag", "-am", msg, body], { cwd });
     }
     if (args.push === true) {

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -91,12 +91,12 @@ export default async function defaultMain(args: Argv) {
         (f) => f && typeof f === "string"
       ) as string[];
       await execa("git", ["add", ...filesToAdd], { cwd });
-      const msg = getCommitMessage(config)
+      const msg = getCommitMessage(config);
       await execa("git", ["commit", "-m", msg], { cwd });
     }
     if (args.tag !== false) {
-      const msg = getTagMessage(config)
-      const body = getTagBody(config)
+      const msg = getTagMessage(config);
+      const body = getTagBody(config);
       await execa("git", ["tag", "-am", msg, body], { cwd });
     }
     if (args.push === true) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,9 +75,7 @@ export async function loadChangelogConfig(
   });
 
   if (!config.from) {
-    config.from = await getLastGitTag(
-      getTagMessagePattern(config),
-    );
+    config.from = await getLastGitTag(getTagMessagePattern(config));
   }
 
   if (!config.to) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { getLastGitTag, getCurrentGitRef } from "./git";
 import { resolveRepoConfig, RepoProvider } from "./repo";
 import type { SemverBumpType } from "./semver";
 import type { RepoConfig } from "./repo";
+import { getTagMessagePattern } from "./template";
 
 export interface ChangelogConfig {
   cwd: string;
@@ -74,7 +75,9 @@ export async function loadChangelogConfig(
   });
 
   if (!config.from) {
-    config.from = await getLastGitTag();
+    config.from = await getLastGitTag(
+      getTagMessagePattern(config),
+    );
   }
 
   if (!config.to) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -26,8 +26,15 @@ export interface GitCommit extends RawGitCommit {
   isBreaking: boolean;
 }
 
-export async function getLastGitTag() {
-  const r = await execCommand("git", ["describe", "--tags", "--abbrev=0"])
+export async function getLastGitTag(
+  pattern?: string
+) {
+  const args = ["describe", "--tags", "--abbrev=0"];
+  if (pattern) {
+    args.push("--match", pattern);
+  }
+
+  const r = await execCommand("git", args)
     .then((r) => r.split("\n"))
     .catch(() => []);
   return r[r.length - 1];

--- a/src/git.ts
+++ b/src/git.ts
@@ -26,9 +26,7 @@ export interface GitCommit extends RawGitCommit {
   isBreaking: boolean;
 }
 
-export async function getLastGitTag(
-  pattern?: string
-) {
+export async function getLastGitTag(pattern?: string) {
   const args = ["describe", "--tags", "--abbrev=0"];
   if (pattern) {
     args.push("--match", pattern);

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,40 +1,32 @@
 import { ChangelogConfig } from "./config";
 
 function format(template: string, vars: Record<string, string>) {
-  const result = template
+  const result = template;
   for (const [key, value] of Object.entries(vars)) {
-    result.replaceAll(key, value)
+    result.replaceAll(key, value);
   }
-  return result
+  return result;
 }
 
-export function getCommitMessage(
-  config: ChangelogConfig,
-) {
+export function getCommitMessage(config: ChangelogConfig) {
   return format(config.templates.commitMessage, {
     "{{newVersion}}": config.newVersion,
   });
 }
 
-export function getTagMessage(
-  config: ChangelogConfig,
-) {
+export function getTagMessage(config: ChangelogConfig) {
   return format(config.templates.tagMessage, {
     "{{newVersion}}": config.newVersion,
   });
 }
 
-export function getTagBody(
-  config: ChangelogConfig,
-) {
+export function getTagBody(config: ChangelogConfig) {
   return format(config.templates.tagBody, {
     "{{newVersion}}": config.newVersion,
   });
 }
 
-export function getTagMessagePattern(
-  config: ChangelogConfig,
-) {
+export function getTagMessagePattern(config: ChangelogConfig) {
   return format(config.templates.tagBody, {
     "{{newVersion}}": "*",
   });

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,0 +1,41 @@
+import { ChangelogConfig } from "./config";
+
+function format(template: string, vars: Record<string, string>) {
+  const result = template
+  for (const [key, value] of Object.entries(vars)) {
+    result.replaceAll(key, value)
+  }
+  return result
+}
+
+export function getCommitMessage(
+  config: ChangelogConfig,
+) {
+  return format(config.templates.commitMessage, {
+    "{{newVersion}}": config.newVersion,
+  });
+}
+
+export function getTagMessage(
+  config: ChangelogConfig,
+) {
+  return format(config.templates.tagMessage, {
+    "{{newVersion}}": config.newVersion,
+  });
+}
+
+export function getTagBody(
+  config: ChangelogConfig,
+) {
+  return format(config.templates.tagBody, {
+    "{{newVersion}}": config.newVersion,
+  });
+}
+
+export function getTagMessagePattern(
+  config: ChangelogConfig,
+) {
+  return format(config.templates.tagBody, {
+    "{{newVersion}}": "*",
+  });
+}

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,9 +1,9 @@
 import { ChangelogConfig } from "./config";
 
 function format(template: string, vars: Record<string, string>) {
-  const result = template;
+  let result = template;
   for (const [key, value] of Object.entries(vars)) {
-    result.replaceAll(key, value);
+    result = result.replaceAll(key, value);
   }
   return result;
 }
@@ -27,7 +27,7 @@ export function getTagBody(config: ChangelogConfig) {
 }
 
 export function getTagMessagePattern(config: ChangelogConfig) {
-  return format(config.templates.tagBody, {
+  return format(config.templates.tagMessage, {
     "{{newVersion}}": "*",
   });
 }

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -1,46 +1,51 @@
 import { describe, test, expect } from "vitest";
-import { getCommitMessage, getTagMessage, getTagBody, getTagMessagePattern } from '../src/template';
+import {
+  getCommitMessage,
+  getTagMessage,
+  getTagBody,
+  getTagMessagePattern,
+} from "../src/template";
 import { ChangelogConfig } from "../src";
 
-describe('template', () => {
-  test('getCommitMessage should work', () => {
+describe("template", () => {
+  test("getCommitMessage should work", () => {
     const result = getCommitMessage({
       templates: {
-        commitMessage: 'v{{newVersion}}'
+        commitMessage: "v{{newVersion}}",
       },
-      newVersion: '1.0.0'
-    } as ChangelogConfig)
+      newVersion: "1.0.0",
+    } as ChangelogConfig);
 
-    expect(result).toBe('v1.0.0')
-  })
-  test('getTagMessage should work', () => {
+    expect(result).toBe("v1.0.0");
+  });
+  test("getTagMessage should work", () => {
     const result = getTagMessage({
       templates: {
-        tagMessage: 'v{{newVersion}}'
+        tagMessage: "v{{newVersion}}",
       },
-      newVersion: '1.0.0'
-    } as ChangelogConfig)
+      newVersion: "1.0.0",
+    } as ChangelogConfig);
 
-    expect(result).toBe('v1.0.0')
-  })
-  test('getTagBody should work', () => {
+    expect(result).toBe("v1.0.0");
+  });
+  test("getTagBody should work", () => {
     const result = getTagBody({
       templates: {
-        tagBody: 'Release new version: v{{newVersion}}'
+        tagBody: "Release new version: v{{newVersion}}",
       },
-      newVersion: '1.0.0'
-    } as ChangelogConfig)
+      newVersion: "1.0.0",
+    } as ChangelogConfig);
 
-    expect(result).toBe('Release new version: v1.0.0')
-  })
-  test('getTagMessagePattern should work', () => {
+    expect(result).toBe("Release new version: v1.0.0");
+  });
+  test("getTagMessagePattern should work", () => {
     const result = getTagMessagePattern({
       templates: {
-        tagMessage: 'v{{newVersion}}'
+        tagMessage: "v{{newVersion}}",
       },
-      newVersion: '1.0.0'
-    } as ChangelogConfig)
+      newVersion: "1.0.0",
+    } as ChangelogConfig);
 
-    expect(result).toBe('v*')
-  })
-})
+    expect(result).toBe("v*");
+  });
+});

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "vitest";
+import { getCommitMessage, getTagMessage, getTagBody, getTagMessagePattern } from '../src/template';
+import { ChangelogConfig } from "../src";
+
+describe('template', () => {
+  test('getCommitMessage should work', () => {
+    const result = getCommitMessage({
+      templates: {
+        commitMessage: 'v{{newVersion}}'
+      },
+      newVersion: '1.0.0'
+    } as ChangelogConfig)
+
+    expect(result).toBe('v1.0.0')
+  })
+  test('getTagMessage should work', () => {
+    const result = getTagMessage({
+      templates: {
+        tagMessage: 'v{{newVersion}}'
+      },
+      newVersion: '1.0.0'
+    } as ChangelogConfig)
+
+    expect(result).toBe('v1.0.0')
+  })
+  test('getTagBody should work', () => {
+    const result = getTagBody({
+      templates: {
+        tagBody: 'Release new version: v{{newVersion}}'
+      },
+      newVersion: '1.0.0'
+    } as ChangelogConfig)
+
+    expect(result).toBe('Release new version: v1.0.0')
+  })
+  test('getTagMessagePattern should work', () => {
+    const result = getTagMessagePattern({
+      templates: {
+        tagMessage: 'v{{newVersion}}'
+      },
+      newVersion: '1.0.0'
+    } as ChangelogConfig)
+
+    expect(result).toBe('v*')
+  })
+})


### PR DESCRIPTION
`getLastGitTag` needs to search for the latest tag based on `templates.tagMessage` set by the user, otherwise it will find the wrong tag.