### PR TITLE
feat!: add option to customize types/scopes to exclude

### DIFF
--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -8,6 +8,7 @@ import {
   getGitDiff,
   getCurrentGitStatus,
   parseCommits,
+  filterParsedCommits,
   bumpVersion,
   generateMarkDown,
   BumpVersionOptions,
@@ -41,11 +42,7 @@ export default async function defaultMain(args: Argv) {
   const rawCommits = await getGitDiff(config.from, config.to);
 
   // Parse commits as conventional commits
-  const commits = parseCommits(rawCommits, config).filter(
-    (c) =>
-      config.types[c.type] &&
-      !(c.type === "chore" && c.scope === "deps" && !c.isBreaking)
-  );
+  const commits = filterParsedCommits(parseCommits(rawCommits, config), config);
 
   // Shortcut for canary releases
   if (args.canary) {

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -29,8 +29,8 @@ export default async function defaultMain(args: Argv) {
       typeof args.exclude === "string"
         ? args.exclude.split(",")
         : args.exclude === 0 // eslint-disable-line unicorn/no-nested-ternary
-        ? [""]
-        : undefined,
+          ? [""]
+          : undefined,
     newVersion: typeof args.r === "string" ? args.r : undefined,
   });
 

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -25,6 +25,8 @@ export default async function defaultMain(args: Argv) {
     from: args.from,
     to: args.to,
     output: args.output,
+    exclude:
+      typeof args.exclude === "string" ? args.exclude.split(",") : (args.exclude === 0 ? [""] : undefined),
     newVersion: typeof args.r === "string" ? args.r : undefined,
   });
 

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -26,7 +26,11 @@ export default async function defaultMain(args: Argv) {
     to: args.to,
     output: args.output,
     exclude:
-      typeof args.exclude === "string" ? args.exclude.split(",") : (args.exclude === 0 ? [""] : undefined),
+      typeof args.exclude === "string"
+        ? args.exclude.split(",")
+        : args.exclude === 0 // eslint-disable-line unicorn/no-nested-ternary
+        ? [""]
+        : undefined,
     newVersion: typeof args.r === "string" ? args.r : undefined,
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,7 @@ const getDefaultConfig = () =>
     cwd: null,
     from: "",
     to: "",
-    exclude: [],
+    exclude: [""],
     output: defaultOutput,
     scopeMap: {},
     tokens: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export interface ChangelogConfig {
   from: string;
   to: string;
   newVersion?: string;
-  excludeChoreDeps: boolean;
+  exclude?: string[];
   signTags?: boolean;
   output: string | boolean;
   publish: {
@@ -54,7 +54,7 @@ const getDefaultConfig = () =>
     cwd: null,
     from: "",
     to: "",
-    excludeChoreDeps: true,
+    exclude: [],
     output: defaultOutput,
     scopeMap: {},
     tokens: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export interface ChangelogConfig {
   from: string;
   to: string;
   newVersion?: string;
+  excludeChoreDeps: boolean;
   signTags?: boolean;
   output: string | boolean;
   publish: {
@@ -53,6 +54,7 @@ const getDefaultConfig = () =>
     cwd: null,
     from: "",
     to: "",
+    excludeChoreDeps: true,
     output: defaultOutput,
     scopeMap: {},
     tokens: {

--- a/src/git.ts
+++ b/src/git.ts
@@ -103,17 +103,20 @@ export function filterParsedCommits(
 ): GitCommit[] {
   // parsing the exclude parameter ('chore(deps)' => ['chore(deps)','chore','(deps)','deps'])
   const excludes: RegExpMatchArray[] = config.exclude
-  ? config.exclude.map((excludeString) =>
-      excludeString.match(/(\*|[a-z]+)(\((.+)\))?/)
-    )
-  : [];
-  console.log(excludes)
-  return commits.filter((c) => 
-    config.types[c.type] && !excludes.some((e) => 
-        e &&
-        (e[1] === "*" || c.type === e[1]) &&
-        (c.scope === e[3] || !e[3]) &&
-        !c.isBreaking)
+    ? config.exclude.map((excludeString) =>
+        excludeString.match(/(\*|[a-z]+)(\((.+)\))?/)
+      )
+    : [];
+  return commits.filter(
+    (c) =>
+      config.types[c.type] &&
+      !excludes.some(
+        (e) =>
+          e &&
+          (e[1] === "*" || c.type === e[1]) &&
+          (c.scope === e[3] || !e[3]) &&
+          !c.isBreaking
+      )
   );
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -97,6 +97,22 @@ export function parseCommits(
     .filter(Boolean);
 }
 
+export function filterParsedCommits(
+  commits: GitCommit[],
+  config: ChangelogConfig
+): GitCommit[] {
+  return commits.filter(
+    (c) =>
+      config.types[c.type] &&
+      !(
+        c.type === "chore" &&
+        config.excludeChoreDeps &&
+        c.scope === "deps" &&
+        !c.isBreaking
+      )
+  );
+}
+
 // https://www.conventionalcommits.org/en/v1.0.0/
 // https://regex101.com/r/FSfNvA/1
 const ConventionalCommitRegex =

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -4,6 +4,7 @@ import {
   getGitDiff,
   loadChangelogConfig,
   parseCommits,
+  filterParsedCommits,
   getRepoConfig,
   formatReference,
 } from "../src";
@@ -104,7 +105,7 @@ describe("git", () => {
     ]);
   });
 
-  test("parse", async () => {
+  test("parse with default config", async () => {
     const COMMIT_FROM = "1cb15d5dd93302ebd5ff912079ed584efcc6703b";
     const COMMIT_TO = "3828bda8c45933396ddfa869d671473231ce3c95";
 
@@ -200,7 +201,204 @@ describe("git", () => {
       from: COMMIT_FROM,
       to: COMMIT_TO,
     });
-    const parsed = parseCommits(commits, config);
+    const parsed = filterParsedCommits(parseCommits(commits, config), config);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    expect(parsed.map(({ body: _, author: __, authors: ___, ...rest }) => rest))
+      .toMatchInlineSnapshot(`
+      [
+        {
+          "description": "v0.3.5",
+          "isBreaking": false,
+          "message": "chore(release): v0.3.5",
+          "references": [
+            {
+              "type": "hash",
+              "value": "3828bda",
+            },
+          ],
+          "scope": "release",
+          "shortHash": "3828bda",
+          "type": "chore",
+        },
+        {
+          "description": "breaking change example, close #123",
+          "isBreaking": true,
+          "message": "fix(scope)!: breaking change example, close #123 (#134)",
+          "references": [
+            {
+              "type": "pull-request",
+              "value": "#134",
+            },
+            {
+              "type": "issue",
+              "value": "#123",
+            },
+            {
+              "type": "hash",
+              "value": "20e622e",
+            },
+          ],
+          "scope": "scope",
+          "shortHash": "20e622e",
+          "type": "fix",
+        },
+        {
+          "description": "v0.3.4",
+          "isBreaking": false,
+          "message": "chore(release): v0.3.4",
+          "references": [
+            {
+              "type": "hash",
+              "value": "6fc5087",
+            },
+          ],
+          "scope": "release",
+          "shortHash": "6fc5087",
+          "type": "chore",
+        },
+        {
+          "description": "infer github config from package.json",
+          "isBreaking": false,
+          "message": "feat: infer github config from package.json (resolves #37)",
+          "references": [
+            {
+              "type": "pull-request",
+              "value": "#37",
+            },
+            {
+              "type": "hash",
+              "value": "c0febf1",
+            },
+          ],
+          "scope": "",
+          "shortHash": "c0febf1",
+          "type": "feat",
+        },
+        {
+          "description": "v0.3.3",
+          "isBreaking": false,
+          "message": "chore(release): v0.3.3",
+          "references": [
+            {
+              "type": "hash",
+              "value": "f4f42a3",
+            },
+          ],
+          "scope": "release",
+          "shortHash": "f4f42a3",
+          "type": "chore",
+        },
+        {
+          "description": "consider docs and refactor as semver patch for bump",
+          "isBreaking": false,
+          "message": "fix: consider docs and refactor as semver patch for bump",
+          "references": [
+            {
+              "type": "hash",
+              "value": "648ccf1",
+            },
+          ],
+          "scope": "",
+          "shortHash": "648ccf1",
+          "type": "fix",
+        },
+        {
+          "description": "expose \`determineSemverChange\` and \`bumpVersion\`",
+          "isBreaking": false,
+          "message": "feat: expose \`determineSemverChange\` and \`bumpVersion\`",
+          "references": [
+            {
+              "type": "hash",
+              "value": "5451f18",
+            },
+          ],
+          "scope": "",
+          "shortHash": "5451f18",
+          "type": "feat",
+        },
+        {
+          "description": "fix typecheck",
+          "isBreaking": false,
+          "message": "chore: fix typecheck",
+          "references": [
+            {
+              "type": "hash",
+              "value": "8796cf1",
+            },
+          ],
+          "scope": "",
+          "shortHash": "8796cf1",
+          "type": "chore",
+        },
+        {
+          "description": "update dependencies",
+          "isBreaking": false,
+          "message": "chore: update dependencies",
+          "references": [
+            {
+              "type": "hash",
+              "value": "c210976",
+            },
+          ],
+          "scope": "",
+          "shortHash": "c210976",
+          "type": "chore",
+        },
+      ]
+    `);
+
+    const md = await generateMarkDown(parsed, config);
+
+    expect(md).toMatchInlineSnapshot(`
+      "## 1cb15d5dd93302ebd5ff912079ed584efcc6703b...3828bda8c45933396ddfa869d671473231ce3c95
+
+      [compare changes](https://github.com/unjs/changelogen/compare/1cb15d5dd93302ebd5ff912079ed584efcc6703b...3828bda8c45933396ddfa869d671473231ce3c95)
+
+
+      ### 🚀 Enhancements
+
+        - Expose \`determineSemverChange\` and \`bumpVersion\` ([5451f18](https://github.com/unjs/changelogen/commit/5451f18))
+        - Infer github config from package.json ([#37](https://github.com/unjs/changelogen/pull/37))
+
+      ### 🩹 Fixes
+
+        - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
+        - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+
+      ### 🏡 Chore
+
+        - Update dependencies ([c210976](https://github.com/unjs/changelogen/commit/c210976))
+        - Fix typecheck ([8796cf1](https://github.com/unjs/changelogen/commit/8796cf1))
+        - **release:** V0.3.3 ([f4f42a3](https://github.com/unjs/changelogen/commit/f4f42a3))
+        - **release:** V0.3.4 ([6fc5087](https://github.com/unjs/changelogen/commit/6fc5087))
+        - **release:** V0.3.5 ([3828bda](https://github.com/unjs/changelogen/commit/3828bda))
+
+      #### ⚠️  Breaking Changes
+
+        - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+
+      ### ❤️  Contributors
+
+      - Pooya Parsa ([@pi0](http://github.com/pi0))"
+    `);
+  });
+
+  test("parse including chore(deps)", async () => {
+    const COMMIT_FROM = "1cb15d5dd93302ebd5ff912079ed584efcc6703b";
+    const COMMIT_TO = "3828bda8c45933396ddfa869d671473231ce3c95";
+
+    const commits = await getGitDiff(COMMIT_FROM, COMMIT_TO);
+    commits[1].message =
+      "fix(scope)!: breaking change example, close #123 (#134)";
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      from: COMMIT_FROM,
+      to: COMMIT_TO,
+      excludeChoreDeps: false,
+    });
+    const parsed = filterParsedCommits(parseCommits(commits, config), config);
 
     expect(parsed.map(({ body: _, author: __, authors: ___, ...rest }) => rest))
       .toMatchInlineSnapshot(`

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -203,7 +203,6 @@ describe("git", () => {
     });
     const parsed = filterParsedCommits(parseCommits(commits, config), config);
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     expect(parsed.map(({ body: _, author: __, authors: ___, ...rest }) => rest))
       .toMatchInlineSnapshot(`
       [
@@ -409,7 +408,6 @@ describe("git", () => {
     const commits = await getGitDiff(COMMIT_FROM, COMMIT_TO);
     commits[1].message =
       "fix(scope)!: breaking change example, close #123 (#134)";
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
     const config = await loadChangelogConfig(process.cwd(), {
       from: COMMIT_FROM,

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -414,7 +414,7 @@ describe("git", () => {
     const config = await loadChangelogConfig(process.cwd(), {
       from: COMMIT_FROM,
       to: COMMIT_TO,
-      exclude: ["fix","chore(deps)"],
+      exclude: ["fix", "chore(deps)"],
     });
     const parsed = filterParsedCommits(parseCommits(commits, config), config);
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -345,6 +345,24 @@ describe("git", () => {
           "shortHash": "c210976",
           "type": "chore",
         },
+        {
+          "description": "update all non-major dependencies",
+          "isBreaking": false,
+          "message": "chore(deps): update all non-major dependencies (#42)",
+          "references": [
+            {
+              "type": "pull-request",
+              "value": "#42",
+            },
+            {
+              "type": "hash",
+              "value": "a80e372",
+            },
+          ],
+          "scope": "deps",
+          "shortHash": "a80e372",
+          "type": "chore",
+        },
       ]
     `);
 
@@ -355,36 +373,36 @@ describe("git", () => {
 
       [compare changes](https://github.com/unjs/changelogen/compare/1cb15d5dd93302ebd5ff912079ed584efcc6703b...3828bda8c45933396ddfa869d671473231ce3c95)
 
-
       ### 🚀 Enhancements
 
-        - Expose \`determineSemverChange\` and \`bumpVersion\` ([5451f18](https://github.com/unjs/changelogen/commit/5451f18))
-        - Infer github config from package.json ([#37](https://github.com/unjs/changelogen/pull/37))
+      - Expose \`determineSemverChange\` and \`bumpVersion\` ([5451f18](https://github.com/unjs/changelogen/commit/5451f18))
+      - Infer github config from package.json ([#37](https://github.com/unjs/changelogen/pull/37))
 
       ### 🩹 Fixes
 
-        - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
-        - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
+      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### 🏡 Chore
 
-        - Update dependencies ([c210976](https://github.com/unjs/changelogen/commit/c210976))
-        - Fix typecheck ([8796cf1](https://github.com/unjs/changelogen/commit/8796cf1))
-        - **release:** V0.3.3 ([f4f42a3](https://github.com/unjs/changelogen/commit/f4f42a3))
-        - **release:** V0.3.4 ([6fc5087](https://github.com/unjs/changelogen/commit/6fc5087))
-        - **release:** V0.3.5 ([3828bda](https://github.com/unjs/changelogen/commit/3828bda))
+      - **deps:** Update all non-major dependencies ([#42](https://github.com/unjs/changelogen/pull/42))
+      - Update dependencies ([c210976](https://github.com/unjs/changelogen/commit/c210976))
+      - Fix typecheck ([8796cf1](https://github.com/unjs/changelogen/commit/8796cf1))
+      - **release:** V0.3.3 ([f4f42a3](https://github.com/unjs/changelogen/commit/f4f42a3))
+      - **release:** V0.3.4 ([6fc5087](https://github.com/unjs/changelogen/commit/6fc5087))
+      - **release:** V0.3.5 ([3828bda](https://github.com/unjs/changelogen/commit/3828bda))
 
-      #### ⚠️  Breaking Changes
+      #### ⚠️ Breaking Changes
 
-        - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
-      ### ❤️  Contributors
+      ### ❤️ Contributors
 
       - Pooya Parsa ([@pi0](http://github.com/pi0))"
     `);
   });
 
-  test("parse including chore(deps)", async () => {
+  test("parse with excluded types and scopes", async () => {
     const COMMIT_FROM = "1cb15d5dd93302ebd5ff912079ed584efcc6703b";
     const COMMIT_TO = "3828bda8c45933396ddfa869d671473231ce3c95";
 
@@ -396,7 +414,7 @@ describe("git", () => {
     const config = await loadChangelogConfig(process.cwd(), {
       from: COMMIT_FROM,
       to: COMMIT_TO,
-      excludeChoreDeps: false,
+      exclude: ["fix","chore(deps)"],
     });
     const parsed = filterParsedCommits(parseCommits(commits, config), config);
 
@@ -486,20 +504,6 @@ describe("git", () => {
           "type": "chore",
         },
         {
-          "description": "consider docs and refactor as semver patch for bump",
-          "isBreaking": false,
-          "message": "fix: consider docs and refactor as semver patch for bump",
-          "references": [
-            {
-              "type": "hash",
-              "value": "648ccf1",
-            },
-          ],
-          "scope": "",
-          "shortHash": "648ccf1",
-          "type": "fix",
-        },
-        {
           "description": "expose \`determineSemverChange\` and \`bumpVersion\`",
           "isBreaking": false,
           "message": "feat: expose \`determineSemverChange\` and \`bumpVersion\`",
@@ -541,24 +545,6 @@ describe("git", () => {
           "shortHash": "c210976",
           "type": "chore",
         },
-        {
-          "description": "update all non-major dependencies",
-          "isBreaking": false,
-          "message": "chore(deps): update all non-major dependencies (#42)",
-          "references": [
-            {
-              "type": "pull-request",
-              "value": "#42",
-            },
-            {
-              "type": "hash",
-              "value": "a80e372",
-            },
-          ],
-          "scope": "deps",
-          "shortHash": "a80e372",
-          "type": "chore",
-        },
       ]
     `);
 
@@ -576,12 +562,10 @@ describe("git", () => {
 
       ### 🩹 Fixes
 
-      - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
       - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### 🏡 Chore
 
-      - **deps:** Update all non-major dependencies ([#42](https://github.com/unjs/changelogen/pull/42))
       - Update dependencies ([c210976](https://github.com/unjs/changelogen/commit/c210976))
       - Fix typecheck ([8796cf1](https://github.com/unjs/changelogen/commit/8796cf1))
       - **release:** V0.3.3 ([f4f42a3](https://github.com/unjs/changelogen/commit/f4f42a3))


### PR DESCRIPTION
The current version of `changelogen` (great piece of work by the way <3) seems opinionated, as it hard codes the exclusion of chore(deps) from changelogs by filtering parsed commits:

https://github.com/unjs/changelogen/blob/db1c625d23db27221a594d7578b78637fc5e8f66/src/commands/default.ts#L34-L38

I like to keep track of the history of my dependencies, so I would like to have the possibility to include those commits in the generated changelog. This is what this PR enables, with an new config option, `excludeChoreDeps` which defaults to `true` as being the current behavior. 

In order to add a corresponding test (with both boolean values of the option), I've decided to export a new function, `filterParsedCommits`, which I can import in the test file and run tests on it. 

I hope that is acceptable :smiley: 