### PR TITLE
fix(markdown): remove unnecessary spaces

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -19,7 +19,7 @@ export async function generateMarkDown(
   markdown.push("", "## " + (v || `${config.from || ""}...${config.to}`), "");
 
   if (config.repo && config.from) {
-    markdown.push(formatCompareChanges(v, config), "");
+    markdown.push(formatCompareChanges(v, config));
   }
 
   for (const type in config.types) {
@@ -128,7 +128,7 @@ export function parseChangelogMarkdown(contents: string) {
 
 function formatCommit(commit: GitCommit, config: ChangelogConfig) {
   return (
-    "  - " +
+    "- " +
     (commit.scope ? `**${commit.scope.trim()}:** ` : "") +
     (commit.isBreaking ? "⚠️  " : "") +
     upperFirst(commit.description) +

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -289,29 +289,28 @@ describe("git", () => {
 
       [compare changes](https://github.com/unjs/changelogen/compare/1cb15d5dd93302ebd5ff912079ed584efcc6703b...3828bda8c45933396ddfa869d671473231ce3c95)
 
-
       ### 🚀 Enhancements
 
-        - Expose \`determineSemverChange\` and \`bumpVersion\` ([5451f18](https://github.com/unjs/changelogen/commit/5451f18))
-        - Infer github config from package.json ([#37](https://github.com/unjs/changelogen/pull/37))
+      - Expose \`determineSemverChange\` and \`bumpVersion\` ([5451f18](https://github.com/unjs/changelogen/commit/5451f18))
+      - Infer github config from package.json ([#37](https://github.com/unjs/changelogen/pull/37))
 
       ### 🩹 Fixes
 
-        - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
-        - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
+      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### 🏡 Chore
 
-        - **deps:** Update all non-major dependencies ([#42](https://github.com/unjs/changelogen/pull/42))
-        - Update dependencies ([c210976](https://github.com/unjs/changelogen/commit/c210976))
-        - Fix typecheck ([8796cf1](https://github.com/unjs/changelogen/commit/8796cf1))
-        - **release:** V0.3.3 ([f4f42a3](https://github.com/unjs/changelogen/commit/f4f42a3))
-        - **release:** V0.3.4 ([6fc5087](https://github.com/unjs/changelogen/commit/6fc5087))
-        - **release:** V0.3.5 ([3828bda](https://github.com/unjs/changelogen/commit/3828bda))
+      - **deps:** Update all non-major dependencies ([#42](https://github.com/unjs/changelogen/pull/42))
+      - Update dependencies ([c210976](https://github.com/unjs/changelogen/commit/c210976))
+      - Fix typecheck ([8796cf1](https://github.com/unjs/changelogen/commit/8796cf1))
+      - **release:** V0.3.3 ([f4f42a3](https://github.com/unjs/changelogen/commit/f4f42a3))
+      - **release:** V0.3.4 ([6fc5087](https://github.com/unjs/changelogen/commit/6fc5087))
+      - **release:** V0.3.5 ([3828bda](https://github.com/unjs/changelogen/commit/3828bda))
 
       #### ⚠️  Breaking Changes
 
-        - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### ❤️  Contributors
 


### PR DESCRIPTION
Removes unnecessary line break after `[compared changes]` and unnecessary leading double space before each commit item.
Prettier keeps reformatting it this way after I generate the changelog via `--bump`

Before:
```
## v0.4.1

[compare changes](https://github.com/unjs/changelogen/compare/v0.4.0...v0.4.1)


### 🩹 Fixes

  - Bump by patch by default ([7e38438](https://github.com/unjs/changelogen/commit/7e38438))
```
After:
```
## v0.4.1

[compare changes](https://github.com/unjs/changelogen/compare/v0.4.0...v0.4.1)

### 🩹 Fixes

- Bump by patch by default ([7e38438](https://github.com/unjs/changelogen/commit/7e38438))
```

Notes:
- the current test fixture already displays this "clean" formatting: https://github.com/unjs/changelogen/blob/main/test/fixtures/CHANGELOG.md
- I'd be happy to update my other PR #103 if you go ahead with this one. Or the other way around.