### PR TITLE
feat: `repo` option as string

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -9,7 +9,7 @@ import {
   syncGithubRelease,
 } from "../github";
 import {
-  ChangelogConfig,
+  ResolvedChangelogConfig,
   loadChangelogConfig,
   parseChangelogMarkdown,
 } from "..";
@@ -93,7 +93,7 @@ export default async function githubMain(args: Argv) {
 }
 
 export async function githubRelease(
-  config: ChangelogConfig,
+  config: ResolvedChangelogConfig,
   release: { version: string; body: string }
 ) {
   if (!config.tokens.github) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -2,7 +2,7 @@ import { existsSync, promises as fsp } from "node:fs";
 import { homedir } from "node:os";
 import { $fetch, FetchOptions } from "ofetch";
 import { join } from "pathe";
-import { ChangelogConfig } from "./config";
+import { ResolvedChangelogConfig } from "./config";
 
 export interface GithubOptions {
   repo: string;
@@ -19,7 +19,7 @@ export interface GithubRelease {
 }
 
 export async function listGithubReleases(
-  config: ChangelogConfig
+  config: ResolvedChangelogConfig
 ): Promise<GithubRelease[]> {
   return await githubFetch(config, `/repos/${config.repo.repo}/releases`, {
     query: { per_page: 100 },
@@ -27,7 +27,7 @@ export async function listGithubReleases(
 }
 
 export async function getGithubReleaseByTag(
-  config: ChangelogConfig,
+  config: ResolvedChangelogConfig,
   tag: string
 ): Promise<GithubRelease> {
   return await githubFetch(
@@ -37,7 +37,7 @@ export async function getGithubReleaseByTag(
   );
 }
 
-export async function getGithubChangelog(config: ChangelogConfig) {
+export async function getGithubChangelog(config: ResolvedChangelogConfig) {
   return await githubFetch(
     config,
     `https://raw.githubusercontent.com/${config.repo.repo}/main/CHANGELOG.md`
@@ -45,7 +45,7 @@ export async function getGithubChangelog(config: ChangelogConfig) {
 }
 
 export async function createGithubRelease(
-  config: ChangelogConfig,
+  config: ResolvedChangelogConfig,
   body: GithubRelease
 ) {
   return await githubFetch(config, `/repos/${config.repo.repo}/releases`, {
@@ -55,7 +55,7 @@ export async function createGithubRelease(
 }
 
 export async function updateGithubRelease(
-  config: ChangelogConfig,
+  config: ResolvedChangelogConfig,
   id: string,
   body: GithubRelease
 ) {
@@ -70,7 +70,7 @@ export async function updateGithubRelease(
 }
 
 export async function syncGithubRelease(
-  config: ChangelogConfig,
+  config: ResolvedChangelogConfig,
   release: { version: string; body: string }
 ) {
   const currentGhRelease = await getGithubReleaseByTag(
@@ -109,7 +109,7 @@ export async function syncGithubRelease(
 }
 
 export function githubNewReleaseURL(
-  config: ChangelogConfig,
+  config: ResolvedChangelogConfig,
   release: { version: string; body: string }
 ) {
   return `https://${config.repo.domain}/${config.repo.repo}/releases/new?tag=v${
@@ -117,7 +117,7 @@ export function githubNewReleaseURL(
   }&title=v${release.version}&body=${encodeURIComponent(release.body)}`;
 }
 
-export async function resolveGithubToken(config: ChangelogConfig) {
+export async function resolveGithubToken(config: ResolvedChangelogConfig) {
   const env =
     process.env.CHANGELOGEN_TOKENS_GITHUB ||
     process.env.GITHUB_TOKEN ||
@@ -140,7 +140,7 @@ export async function resolveGithubToken(config: ChangelogConfig) {
 
 // --- Internal utils ---
 async function githubFetch(
-  config: ChangelogConfig,
+  config: ResolvedChangelogConfig,
   url: string,
   opts: FetchOptions = {}
 ) {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,13 +1,13 @@
 import { upperFirst } from "scule";
 import { convert } from "convert-gitmoji";
 import { fetch } from "node-fetch-native";
-import type { ChangelogConfig } from "./config";
+import type { ResolvedChangelogConfig } from "./config";
 import type { GitCommit, Reference } from "./git";
 import { formatReference, formatCompareChanges } from "./repo";
 
 export async function generateMarkDown(
   commits: GitCommit[],
-  config: ChangelogConfig
+  config: ResolvedChangelogConfig
 ) {
   const typeGroups = groupBy(commits, "type");
 
@@ -126,7 +126,7 @@ export function parseChangelogMarkdown(contents: string) {
 
 // --- Internal utils ---
 
-function formatCommit(commit: GitCommit, config: ChangelogConfig) {
+function formatCommit(commit: GitCommit, config: ResolvedChangelogConfig) {
   return (
     "- " +
     (commit.scope ? `**${commit.scope.trim()}:** ` : "") +
@@ -136,7 +136,10 @@ function formatCommit(commit: GitCommit, config: ChangelogConfig) {
   );
 }
 
-function formatReferences(references: Reference[], config: ChangelogConfig) {
+function formatReferences(
+  references: Reference[],
+  config: ResolvedChangelogConfig
+) {
   const pr = references.filter((ref) => ref.type === "pull-request");
   const issue = references.filter((ref) => ref.type === "issue");
   if (pr.length > 0 || issue.length > 0) {

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,6 +1,6 @@
 import { readPackageJSON } from "pkg-types";
 import type { Reference } from "./git";
-import type { ChangelogConfig } from "./config";
+import type { ResolvedChangelogConfig } from "./config";
 import { getGitRemoteURL } from "./git";
 
 export type RepoProvider = "github" | "gitlab" | "bitbucket";
@@ -55,7 +55,10 @@ export function formatReference(ref: Reference, repo?: RepoConfig) {
   }/${ref.value.replace(/^#/, "")})`;
 }
 
-export function formatCompareChanges(v: string, config: ChangelogConfig) {
+export function formatCompareChanges(
+  v: string,
+  config: ResolvedChangelogConfig
+) {
   const part =
     config.repo.provider === "bitbucket" ? "branches/compare" : "compare";
   return `[compare changes](${baseUrl(config.repo)}/${part}/${config.from}...${


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow the `repo` option to be string, and then resolve it with `getRepoConfig`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
