### PR TITLE
feat: update `package.json` while preserve indent & eol style

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "consola": "^3.2.3",
     "convert-gitmoji": "^0.1.3",
     "execa": "^7.1.1",
+    "jsonc-parser": "^3.2.0",
     "mri": "^1.2.0",
     "node-fetch-native": "^1.2.0",
     "ofetch": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   execa:
     specifier: ^7.1.1
     version: 7.1.1
+  jsonc-parser:
+    specifier: ^3.2.0
+    version: 3.2.0
   mri:
     specifier: ^1.2.0
     version: 1.2.0

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -2,7 +2,7 @@ import semver from "semver";
 import consola from "consola";
 import type { ChangelogConfig } from "./config";
 import type { GitCommit } from "./git";
-import { readPackageJSON, writePackageJSON } from "./package";
+import { readPackageJSON, updatePackageVersion } from "./package";
 
 export type SemverBumpType =
   | "major"
@@ -82,7 +82,7 @@ export async function bumpVersion(
     `Bumping npm package version from \`${currentVersion}\` to \`${pkg.version}\` (${originalType})`
   );
 
-  await writePackageJSON(config, pkg);
+  await updatePackageVersion(config, pkg.version);
 
   return pkg.version;
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use [`jsonc-parser`](https://github.com/microsoft/node-jsonc-parser) to modify the package json string to preserve its indent & eol style

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
