### PR TITLE
feat(git): support parse git messages that have prefix emoji

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -100,7 +100,7 @@ export function parseCommits(
 // https://www.conventionalcommits.org/en/v1.0.0/
 // https://regex101.com/r/FSfNvA/1
 const ConventionalCommitRegex =
-  /(?<type>[a-z]+)(\((?<scope>.+)\))?(?<breaking>!)?: (?<description>.+)/i;
+  /(?<emoji>:.+:|(\uD83C[\uDF00-\uDFFF])|(\uD83D[\uDC00-\uDE4F\uDE80-\uDEFF])|[\u2600-\u2B55])?( *)?(?<type>[a-z]+)(\((?<scope>.+)\))?(?<breaking>!)?: (?<description>.+)/i;
 const CoAuthoredByRegex = /co-authored-by:\s*(?<name>.+)(<(?<email>.+)>)/gim;
 const PullRequestRE = /\([ a-z]*(#\d+)\s*\)/gm;
 const IssueRE = /(#\d+)/gm;

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -56,7 +56,6 @@ describe("git", () => {
       await loadChangelogConfig(process.cwd(), {})
     );
 
-    console.log(JSON.stringify(parsed));
     expect(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       parsed.map(({ body: _, author: __, authors: ___, ...rest }) => rest)

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -21,6 +21,91 @@ describe("git", () => {
     );
   });
 
+  test("parse commit with emoji", async () => {
+    const rawCommitEmojiList = [
+      {
+        message: "🚀 feat: add emoji support",
+        shortHash: "0000000",
+        body: "this is a emoji commit",
+        author: {
+          email: "jannchie@gmail.com",
+          name: "Jannchie",
+        },
+      },
+      {
+        message: ":bug: fix: this is a text emoji",
+        shortHash: "0000001",
+        body: "this is a emoji commit",
+        author: {
+          email: "jannchie@gmail.com",
+          name: "Jannchie",
+        },
+      },
+      {
+        message: ":bug: fix(scope): this is a text emoji with scope",
+        shortHash: "0000001",
+        body: "this is a emoji commit",
+        author: {
+          email: "jannchie@gmail.com",
+          name: "Jannchie",
+        },
+      },
+    ];
+    const parsed = parseCommits(
+      rawCommitEmojiList,
+      await loadChangelogConfig(process.cwd(), {})
+    );
+
+    console.log(JSON.stringify(parsed));
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      parsed.map(({ body: _, author: __, authors: ___, ...rest }) => rest)
+    ).toMatchObject([
+      {
+        message: "🚀 feat: add emoji support",
+        shortHash: "0000000",
+        description: "add emoji support",
+        type: "feat",
+        scope: "",
+        references: [
+          {
+            value: "0000000",
+            type: "hash",
+          },
+        ],
+        isBreaking: false,
+      },
+      {
+        message: ":bug: fix: this is a text emoji",
+        shortHash: "0000001",
+        description: "this is a text emoji",
+        type: "fix",
+        scope: "",
+        references: [
+          {
+            value: "0000001",
+            type: "hash",
+          },
+        ],
+        isBreaking: false,
+      },
+      {
+        message: ":bug: fix(scope): this is a text emoji with scope",
+        shortHash: "0000001",
+        description: "this is a text emoji with scope",
+        type: "fix",
+        scope: "scope",
+        references: [
+          {
+            value: "0000001",
+            type: "hash",
+          },
+        ],
+        isBreaking: false,
+      },
+    ]);
+  });
+
   test("parse", async () => {
     const COMMIT_FROM = "1cb15d5dd93302ebd5ff912079ed584efcc6703b";
     const COMMIT_TO = "3828bda8c45933396ddfa869d671473231ce3c95";


### PR DESCRIPTION
### 🔗 Linked issue

- Resolve #145 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Although not part of the `conventionalcommits` standard, it is common practice for git messages to be prefixed with emoji.
This PR allows parsing prefixed string emoji (e.g., `:bug:`) and Unicode emoji (e.g., 🐞).
I ran unit tests to make sure it wouldn't affect the original parsing. I also wrote the appropriate unit tests for emoji parsing.

**Need for discussion**
Theoretically, unless someone uses emoji to prevent commits from being added to the changelog, it's senseless. So I just modified the original regex.
If we must obey `conventionalcommits`, we may need to expose the regex to config.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
