### PR TITLE
feat: lookup Github username if token is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 dist
 types
 .conf*
+.env

--- a/src/author.ts
+++ b/src/author.ts
@@ -1,0 +1,111 @@
+import { upperFirst } from "scule";
+import { ResolvedChangelogConfig } from "./config";
+import { GitCommit } from "./git";
+import { getGithubLoginByCommit } from "./github";
+
+export interface GithubAuthor {
+  commits: string[];
+  github?: string;
+  email: Set<string>;
+  name: string;
+}
+
+export async function resolveAuthorInfo(
+  config: ResolvedChangelogConfig,
+  info: GithubAuthor
+) {
+  if (info.github) {
+    return info;
+  }
+
+  try {
+    for (const email of info.email) {
+      const { user } = await fetch(`https://ungh.cc/users/find/${email}`)
+        .then((r) => r.json())
+        .catch(() => ({ user: null }));
+      if (user) {
+        info.github = user.username;
+        break;
+      }
+    }
+  } catch {}
+
+  if (info.github) {
+    return info;
+  }
+
+  // token not provided, skip github resolving
+  if (!config.tokens.github) {
+    return info;
+  }
+
+  if (info.commits.length > 0) {
+    try {
+      info.github = await getGithubLoginByCommit(config, info.commits[0]);
+    } catch {}
+  }
+
+  return info;
+}
+
+export async function resolveAuthors(
+  commits: GitCommit[],
+  config: ResolvedChangelogConfig
+) {
+  const _authors = new Map<string, GithubAuthor>();
+  for (const commit of commits) {
+    if (!commit.author) {
+      continue;
+    }
+    const name = formatName(commit.author.name);
+    if (!name || name.includes("[bot]")) {
+      continue;
+    }
+    if (
+      config.excludeAuthors &&
+      config.excludeAuthors.some(
+        (v) => name.includes(v) || commit.author.email?.includes(v)
+      )
+    ) {
+      continue;
+    }
+    if (_authors.has(name)) {
+      const entry = _authors.get(name);
+      entry.email.add(commit.author.email);
+      entry.commits.push(commit.shortHash);
+    } else {
+      _authors.set(name, {
+        name,
+        email: new Set([commit.author.email]),
+        commits: [commit.shortHash],
+      });
+    }
+  }
+
+  // Try to map authors to github usernames
+  const authors = [..._authors.values()];
+  const resolved = await Promise.all(
+    authors.map((info) => resolveAuthorInfo(config, info))
+  );
+
+  // check for duplicate logins
+  const loginSet = new Set<string>();
+  return resolved.filter((i) => {
+    if (i.github && loginSet.has(i.github)) {
+      return false;
+    }
+    if (i.github) {
+      loginSet.add(i.github);
+    }
+    return true;
+  });
+}
+
+// --- Internal utils ---
+
+function formatName(name = "") {
+  return name
+    .split(" ")
+    .map((p) => upperFirst(p.trim()))
+    .join(" ");
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -26,6 +26,18 @@ export async function listGithubReleases(
   });
 }
 
+export async function getGithubLoginByCommit(
+  config: ResolvedChangelogConfig,
+  commit: string
+): Promise<string> {
+  const data = await githubFetch(
+    config,
+    `/repos/${config.repo.repo}/commits/${commit}`,
+    {}
+  );
+  return data?.author?.login;
+}
+
 export async function getGithubReleaseByTag(
   config: ResolvedChangelogConfig,
   tag: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./markdown";
 export * from "./config";
 export * from "./semver";
 export * from "./repo";
+export * from "./author";

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,9 +1,9 @@
 import { upperFirst } from "scule";
 import { convert } from "convert-gitmoji";
-import { fetch } from "node-fetch-native";
 import type { ResolvedChangelogConfig } from "./config";
 import type { GitCommit, Reference } from "./git";
 import { formatReference, formatCompareChanges } from "./repo";
+import { resolveAuthors } from "./author";
 
 export async function generateMarkDown(
   commits: GitCommit[],
@@ -42,48 +42,7 @@ export async function generateMarkDown(
     markdown.push("", "#### ⚠️ Breaking Changes", "", ...breakingChanges);
   }
 
-  const _authors = new Map<string, { email: Set<string>; github?: string }>();
-  for (const commit of commits) {
-    if (!commit.author) {
-      continue;
-    }
-    const name = formatName(commit.author.name);
-    if (!name || name.includes("[bot]")) {
-      continue;
-    }
-    if (
-      config.excludeAuthors &&
-      config.excludeAuthors.some(
-        (v) => name.includes(v) || commit.author.email?.includes(v)
-      )
-    ) {
-      continue;
-    }
-    if (_authors.has(name)) {
-      const entry = _authors.get(name);
-      entry.email.add(commit.author.email);
-    } else {
-      _authors.set(name, { email: new Set([commit.author.email]) });
-    }
-  }
-
-  // Try to map authors to github usernames
-  await Promise.all(
-    [..._authors.keys()].map(async (authorName) => {
-      const meta = _authors.get(authorName);
-      for (const email of meta.email) {
-        const { user } = await fetch(`https://ungh.cc/users/find/${email}`)
-          .then((r) => r.json())
-          .catch(() => ({ user: null }));
-        if (user) {
-          meta.github = user.username;
-          break;
-        }
-      }
-    })
-  );
-
-  const authors = [..._authors.entries()].map((e) => ({ name: e[0], ...e[1] }));
+  const authors = await resolveAuthors(commits, config);
 
   if (authors.length > 0) {
     markdown.push(

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -128,13 +128,6 @@ function formatReferences(
 //   return title.length <= 3 ? title.toUpperCase() : upperFirst(title)
 // }
 
-function formatName(name = "") {
-  return name
-    .split(" ")
-    .map((p) => upperFirst(p.trim()))
-    .join(" ");
-}
-
 function groupBy(items: any[], key: string) {
   const groups = {};
   for (const item of items) {

--- a/test/author.test.ts
+++ b/test/author.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "vitest";
+import {
+  getGitDiff,
+  loadChangelogConfig,
+  parseCommits,
+  resolveAuthors,
+} from "../src";
+const config = await loadChangelogConfig(process.cwd());
+describe("author", () => {
+  test.runIf(config.tokens.github)(
+    "resolves author info with GitHub token",
+    async () => {
+      const COMMIT_FROM = "610934e644e690c8d0d77197d018498fc43ab0e9";
+      const COMMIT_TO = "14fa199c295a6e7620ff373a043790414d795fa5";
+
+      const commits = await getGitDiff(COMMIT_FROM, COMMIT_TO);
+      commits[1].message =
+        "fix(scope)!: breaking change example, close #123 (#134)";
+
+      const config = await loadChangelogConfig(process.cwd(), {
+        from: COMMIT_FROM,
+        to: COMMIT_TO,
+      });
+
+      const parsed = parseCommits(commits, config);
+      const authors = await resolveAuthors(parsed, config);
+      expect(authors).toMatchInlineSnapshot(
+        `
+    [
+      {
+        "commits": [
+          "14fa199",
+          "5bfe08e",
+          "cb9adf4",
+          "81f37bf",
+          "de240e5",
+        ],
+        "email": Set {
+          "pooya@pi0.io",
+        },
+        "github": "pi0",
+        "name": "Pooya Parsa",
+      },
+      {
+        "commits": [
+          "aa1a650",
+          "6fd8dbb",
+        ],
+        "email": Set {
+          "john@brightshore.com",
+        },
+        "github": "JohnCampionJr",
+        "name": "John Campion Jr",
+      },
+      {
+        "commits": [
+          "d0acbfd",
+          "46f60cc",
+        ],
+        "email": Set {
+          "waleed1kh@outlook.com",
+        },
+        "github": "Waleed-KH",
+        "name": "Waleed Khaled",
+      },
+      {
+        "commits": [
+          "5b68aed",
+        ],
+        "email": Set {
+          "kapustka.maciek@gmail.com",
+        },
+        "github": "maciej-ka",
+        "name": "Maciej Kasprzyk",
+      },
+      {
+        "commits": [
+          "1e5f0b7",
+        ],
+        "email": Set {
+          "daniel@roe.dev",
+        },
+        "github": "danielroe",
+        "name": "Daniel Roe",
+      },
+      {
+        "commits": [
+          "ec858d1",
+        ],
+        "email": Set {
+          "me@loicmazuel.com",
+        },
+        "github": "LouisMazel",
+        "name": "Mazel",
+      },
+    ]
+  `
+      );
+    }
+  );
+  test.runIf(!config.tokens.github)(
+    "resolves author info witout Github token",
+    async () => {
+      const COMMIT_FROM = "610934e644e690c8d0d77197d018498fc43ab0e9";
+      const COMMIT_TO = "14fa199c295a6e7620ff373a043790414d795fa5";
+
+      const commits = await getGitDiff(COMMIT_FROM, COMMIT_TO);
+      commits[1].message =
+        "fix(scope)!: breaking change example, close #123 (#134)";
+
+      const config = await loadChangelogConfig(process.cwd(), {
+        from: COMMIT_FROM,
+        to: COMMIT_TO,
+      });
+
+      const parsed = parseCommits(commits, config);
+      const authors = await resolveAuthors(parsed, config);
+      expect(authors).toMatchInlineSnapshot(
+        `
+        [
+          {
+            "commits": [
+              "14fa199",
+              "5bfe08e",
+              "cb9adf4",
+              "81f37bf",
+              "de240e5",
+            ],
+            "email": Set {
+              "pooya@pi0.io",
+            },
+            "github": "pi0",
+            "name": "Pooya Parsa",
+          },
+          {
+            "commits": [
+              "aa1a650",
+              "6fd8dbb",
+            ],
+            "email": Set {
+              "john@brightshore.com",
+            },
+            "name": "John Campion Jr",
+          },
+          {
+            "commits": [
+              "d0acbfd",
+              "46f60cc",
+            ],
+            "email": Set {
+              "waleed1kh@outlook.com",
+            },
+            "github": "Waleed-KH",
+            "name": "Waleed Khaled",
+          },
+          {
+            "commits": [
+              "5b68aed",
+            ],
+            "email": Set {
+              "kapustka.maciek@gmail.com",
+            },
+            "name": "Maciej Kasprzyk",
+          },
+          {
+            "commits": [
+              "1e5f0b7",
+            ],
+            "email": Set {
+              "daniel@roe.dev",
+            },
+            "name": "Daniel Roe",
+          },
+          {
+            "commits": [
+              "ec858d1",
+            ],
+            "email": Set {
+              "me@loicmazuel.com",
+            },
+            "name": "Mazel",
+          },
+        ]
+      `
+      );
+    }
+  );
+});


### PR DESCRIPTION
### 🔗 Linked issue

#116 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using @antfu's [changelogithub](https://github.com/antfu/changelogithub) as inspiration, I added this feature to changelogen.

If a GitHub token is available, it will retrieve usernames through the GitHub API.  Otherwise, it returns the exact same author info as before.

Added tests with both a token and without a token.

Resolves #116 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
