### PR TITLE
feat: add support for breaking change token in the message footer

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -102,6 +102,7 @@ export function parseCommits(
 const ConventionalCommitRegex =
   /(?<type>[a-z]+)(\((?<scope>.+)\))?(?<breaking>!)?: (?<description>.+)/i;
 const CoAuthoredByRegex = /co-authored-by:\s*(?<name>.+)(<(?<email>.+)>)/gim;
+const BreakingChangeBodyRegex = /BREAKING[ -]CHANGE: (?<description>.+)/gm;
 const PullRequestRE = /\([ a-z]*(#\d+)\s*\)/gm;
 const IssueRE = /(#\d+)/gm;
 
@@ -119,8 +120,12 @@ export function parseGitCommit(
   let scope = match.groups.scope || "";
   scope = config.scopeMap[scope] || scope;
 
-  const isBreaking = Boolean(match.groups.breaking);
+  const breakingMatch = BreakingChangeBodyRegex.exec(commit.body);
+  const isBreaking = Boolean(match.groups.breaking || breakingMatch);
   let description = match.groups.description;
+  if (breakingMatch) {
+    description = breakingMatch.groups.description;
+  }
 
   // Extract references from message
   const references: Reference[] = [];

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -6,6 +6,7 @@ import {
   parseCommits,
   getRepoConfig,
   formatReference,
+  parseGitCommit,
 } from "../src";
 import { RepoConfig } from "./../src/repo";
 
@@ -473,5 +474,39 @@ describe("git", () => {
     expect(formatReference({ type: "issue", value: "#14" }, unkown)).toBe(
       "#14"
     );
+  });
+
+  test("breaking change on body", async () => {
+    const commit = {
+      message: "feat: some breaking change in the footer",
+      shortHash: "c210976",
+      author: {
+        name: "Pooya Parsa",
+        email: "pooya@pi0.io",
+      },
+      body: "\n\nBREAKING-CHANGE: Test footer breaking change.",
+    };
+
+    const config = await loadChangelogConfig(process.cwd());
+    const parsedCommit = parseGitCommit(commit, config);
+    expect(parsedCommit.isBreaking).toBe(true);
+    expect(parsedCommit.description).toBe("Test footer breaking change.");
+  });
+
+  test("breaking change honor commit description", async () => {
+    const commit = {
+      message: "feat!: some breaking change in the footer",
+      shortHash: "c210976",
+      author: {
+        name: "Pooya Parsa",
+        email: "pooya@pi0.io",
+      },
+      body: "\n\nBREAKING-CHANGE: Test footer breaking change.",
+    };
+
+    const config = await loadChangelogConfig(process.cwd());
+    const parsedCommit = parseGitCommit(commit, config);
+    expect(parsedCommit.isBreaking).toBe(true);
+    expect(parsedCommit.description).toBe("some breaking change in the footer");
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

#112

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #112 

Extends support for signalling breaking changes in commit messages according to the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification) (see points 11, 12, 13, 15 and 16).

Previously, only the suffix `!` after the type/scope was recognized as a breaking change. With this change, the footer "BREAKING CHANGE" or "BREAKING-CHANGE" will also be identified (as per point 11, 12 and 16 of the specification), these are NOT case-sensitive (as per point 15 of the specification).

The footer `BREAKING CHANGE` can be omitted as per point 13 of the specification.

Additionally, the description given in `BREAKING CHANGE` will be used if present instead of the commit description unless the commit includes the `!` suffix after the type/scope (as per point 12 of the specification).

For reference these are the points of the specifications that are being implemented:

> 11: Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
> 12: If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., BREAKING CHANGE: environment variables now take precedence over config files.
> 13: If included in the type/scope prefix, breaking changes MUST be indicated by a ! immediately before the :. If ! is used, BREAKING CHANGE: MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
> 15: The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
> 16: BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
