### PR TITLE
fix: handle repo name with multiple segments

### DIFF
--- a/src/repo.ts
+++ b/src/repo.ts
@@ -86,7 +86,7 @@ export function getRepoConfig(repoUrl = ""): RepoConfig {
   let repo;
   let domain;
 
-  let url;
+  let url: URL;
   try {
     url = new URL(repoUrl);
   } catch {
@@ -104,9 +104,9 @@ export function getRepoConfig(repoUrl = ""): RepoConfig {
       provider in providerToDomain ? providerToDomain[provider] : provider;
   } else if (url) {
     domain = url.hostname;
-    repo = url.pathname
-      .split("/")
-      .slice(1, 3)
+    const paths = url.pathname.split("/");
+    repo = paths
+      .slice(1, paths.length)
       .join("/")
       .replace(/\.git$/, "");
     provider = domainToProvider[domain];

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+import { getRepoConfig } from "../src";
+
+describe("repo", () => {
+  describe("getRepoConfig", () => {
+    describe("when `m.repo` and `m.provider` are defined", () => {
+      test.each([
+        {
+          input: "github:donaldsh/test",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "donaldsh/test",
+          },
+        },
+        {
+          input: "gitlab:donaldsh/test.git",
+          output: {
+            domain: "gitlab.com",
+            provider: "gitlab",
+            repo: "donaldsh/test",
+          },
+        },
+        {
+          input: "gitlab:donaldsh/test.git",
+          output: {
+            domain: "gitlab.com",
+            provider: "gitlab",
+            repo: "donaldsh/test",
+          },
+        },
+        {
+          input: "git@bitbucket.org:donaldsh/test.git",
+          output: {
+            domain: "bitbucket.org",
+            provider: "bitbucket",
+            repo: "donaldsh/test",
+          },
+        },
+        {
+          input: "a@x:b/c",
+          output: {
+            domain: "x",
+            provider: "x",
+            repo: "b/c",
+          },
+        },
+      ])("url=$input should return RepoConfig", ({ input, output }) => {
+        expect(getRepoConfig(input)).toEqual(output);
+      });
+    });
+
+    describe("when `url` is defined", () => {
+      test.each([
+        {
+          input: "https://github.com/unjs/changelogen.git",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "unjs/changelogen",
+          },
+        },
+        {
+          input: "https://github.com/unjs/changelogen",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "unjs/changelogen",
+          },
+        },
+        {
+          input: "https://github.com/myproject.git",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "myproject",
+          },
+        },
+        {
+          input: "https://github.com/account/project/sub1/sub2/myproject.git",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "account/project/sub1/sub2/myproject",
+          },
+        },
+      ])("url=$input should return RepoConfig", ({ input, output }) => {
+        expect(getRepoConfig(input)).toEqual(output);
+      });
+    });
+
+    describe("when only `m.repo` is defined", () => {
+      test.each([
+        {
+          input: "donaldsh/test.git",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "donaldsh/test",
+          },
+        },
+        {
+          input: "unjs/changelogen",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "unjs/changelogen",
+          },
+        },
+      ])("url=$input should return RepoConfig", ({ input, output }) => {
+        expect(getRepoConfig(input)).toEqual(output);
+      });
+    });
+
+    describe("when `repoUrl` is empty", () => {
+      test("should return empty RepoConfig", () => {
+        expect(getRepoConfig()).toEqual({});
+      });
+    });
+  });
+});


### PR DESCRIPTION
Resolves #218

Reproduction steps described in the issue. If preferred can also be reproduced in the unit tests after the fix is reverted.  