### PR TITLE
refactor: use human readable date for canary versions

### DIFF
--- a/src/semver.ts
+++ b/src/semver.ts
@@ -87,7 +87,7 @@ export async function bumpVersion(
 }
 
 function fmtDate(d: Date): string {
-  // YYMMDD-HHMMSS: 2024819-135530
+  // YYMMDD-HHMMSS: 20240919-140954
   const date = joinNumbers([d.getFullYear(), d.getMonth() + 1, d.getDate()]);
   const time = joinNumbers([d.getHours(), d.getMinutes(), d.getSeconds()]);
   return `${date}-${time}`;


### PR DESCRIPTION
Use more human-friendly dates in the canary version like `20240919-140954` instead of `1726746896` (4 more chars) but still sortable and safe with seconds precision.

Also using `+` instead of `-`.TIL, it is an npm convention for build-metadata. Example `1.0.0+build.1`

