### PR TITLE
fix(bump): avoid using `+` for canary suffix

### DIFF
--- a/src/semver.ts
+++ b/src/semver.ts
@@ -69,7 +69,7 @@ export async function bumpVersion(
     const suffix =
       typeof opts.suffix === "string"
         ? `-${opts.suffix}`
-        : `+${fmtDate(new Date())}-${commits[0].shortHash}`;
+        : `-${fmtDate(new Date())}-${commits[0].shortHash}`;
     pkg.version = config.newVersion = config.newVersion.split("-")[0] + suffix;
   }
 


### PR DESCRIPTION
Resolve regression with #223

npm **cleans up** (!) the `+*` part

<img width="805" alt="image" src="https://github.com/user-attachments/assets/f14a0593-87db-481a-bd75-4b55ce4a5606">
