### PR TITLE
feat(git): add merge filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npx changelogen@latest [...args] [--dir <dir>]
 - `--noAuthors`: Skip contributors section in changelog.
 - `--bump`: Determine semver change and update version in `package.json`.
 - `--release`. Bumps version in `package.json`, creates a commit and git tags using local `git`, and **creates or updates a GitHub release** for the new version when the repository provider is GitHub. You can disable commit using `--no-commit`, tag using `--no-tag`, and the GitHub release using `--no-github`. You can enable the automatic push of the new tag and release commit to your git repository by adding `--push`.
+- `--onlyMerges`: Use merge commits in changelog.
+- `--noMerges`: Exclude merge commits in changelog.
 - `--publish`. Publishes package as a new version on `npm`. You will need to set authorisation tokens separately via `.npmrc` or environment variables.
 - `--publishTag` Use custom npm tag for publishing (Default is `latest`)
 - `--nameSuffix`: Adds suffix to package name (Example: `--nameSuffix canary` renames `foo` to `foo-canary`)

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -42,6 +42,8 @@ const argsSpec = {
   preminor: { type: "optional" },
   prepatch: { type: "optional" },
   prerelease: { type: "optional" },
+  onlyMerges: { type: "boolean" },
+  noMerges: { type: "boolean" },
 } as const satisfies ArgsSpec;
 
 export default async function defaultMain(rawArgs: string[]) {
@@ -71,7 +73,20 @@ export default async function defaultMain(rawArgs: string[]) {
   const logger = consola.create({ stdout: process.stderr });
   logger.info(`Generating changelog for ${config.from || ""}...${config.to}`);
 
-  const rawCommits = await getGitDiff(config.from, config.to, config.cwd);
+  let onlyMerges: boolean;
+  if (args.onlyMerges) {
+    onlyMerges = true;
+  }
+  if (args.noMerges) {
+    onlyMerges = false;
+  }
+
+  const rawCommits = await getGitDiff(
+    config.from,
+    config.to,
+    config.cwd,
+    onlyMerges
+  );
 
   // Parse commits as conventional commits
   const commits = parseCommits(rawCommits, config)

--- a/src/git.ts
+++ b/src/git.ts
@@ -63,12 +63,21 @@ export async function getCurrentGitStatus(cwd?: string) {
 export async function getGitDiff(
   from: string | undefined,
   to = "HEAD",
-  cwd?: string
+  cwd?: string,
+  onlyMerges?: boolean
 ): Promise<RawGitCommit[]> {
+  let mergeFilter = "";
+  if (onlyMerges === true) {
+    mergeFilter = "--merges";
+  }
+  if (onlyMerges === false) {
+    mergeFilter = "--no-merges";
+  }
+
   // https://git-scm.com/docs/pretty-formats
   const r = execCommand(
-    `git --no-pager log "${from ? `${from}...` : ""}${to}" --pretty="----%n%s|%h|%an|%ae%n%b" --name-status`,
-    cwd
+    `git --no-pager log "${from ? `${from}...` : ""}${to}" --pretty="----%n%s|%h|%an|%ae%n%b" --name-status ${mergeFilter}`,
+    cwd,
   );
   return r
     .split("----\n")

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -6,6 +6,8 @@ const spec = {
   r: { type: "string", short: "r" },
   bump: { type: "boolean" },
   commit: { type: "boolean" },
+  onlyMerges: { type: "boolean" },
+  noMerges: { type: "boolean" },
   output: { type: "optional" },
   canary: { type: "optional" },
 } as const satisfies ArgsSpec;
@@ -36,6 +38,8 @@ describe("parseCliArgs", () => {
       expected: { _: ["release", "1.0.0"], dir: "." },
     },
     { args: ["--", "--bump"], expected: { _: ["--bump"] } },
+    { args: ["--onlyMerges"], expected: { _: [], onlyMerges: true } },
+    { args: ["--noMerges"], expected: { _: [], noMerges: true } },
   ])("$args", ({ args, expected }) => {
     expect(parseCliArgs(args, spec)).toEqual(expected);
   });

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "pathe";
 import { describe, expect, test } from "vitest";
 import {
   generateMarkDown,
@@ -8,6 +11,7 @@ import {
   formatReference,
 } from "../src";
 import { RepoConfig } from "./../src/repo";
+import { execCommand } from "../src/exec";
 
 describe("git", () => {
   test("getGitDiff should work", async () => {
@@ -19,6 +23,42 @@ describe("git", () => {
     expect((await getGitDiff(COMMIT_INITIAL, "HEAD")).length + 1).toBe(
       all.length
     );
+  });
+
+  test("getGitDiff should apply merge filter", async () => {
+    const cwd = await mkdtemp(resolve(tmpdir(), "changelogen-git-"));
+    const git = (cmd: string) => execCommand(`git ${cmd}`, cwd);
+    try {
+      git("init -q -b main");
+      git("config user.name test");
+      git("config user.email test@example.com");
+      git("commit -q --allow-empty -m 'chore: initial commit'");
+      git("checkout -q -b feature");
+      git("commit -q --allow-empty -m 'feat: on feature branch'");
+      git("checkout -q main");
+      git("commit -q --allow-empty -m 'fix: on main'");
+      git("merge -q --no-ff -m 'Merge branch feature' feature");
+
+      const messages = async (onlyMerges?: boolean) =>
+        (await getGitDiff(undefined, "HEAD", cwd, onlyMerges)).map(
+          (c) => c.message
+        );
+
+      expect(await messages(undefined)).toEqual([
+        "Merge branch feature",
+        "fix: on main",
+        "feat: on feature branch",
+        "chore: initial commit",
+      ]);
+      expect(await messages(true)).toEqual(["Merge branch feature"]);
+      expect(await messages(false)).toEqual([
+        "fix: on main",
+        "feat: on feature branch",
+        "chore: initial commit",
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   test("parse commit with emoji", async () => {


### PR DESCRIPTION
Added filtering options for merge commits.

I attempted to add tests and a reproduction but was unsure how to make it.
If something is missing or needs to be changed please let me knkow.

resolves #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--onlyMerges` to generate changelogs containing only merge commits.
  * Added `--noMerges` to exclude merge commits from changelogs.
  * Without either option, changelog behavior remains unchanged.
  * Merge filtering can now be selected directly through command-line options for greater control over changelog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->