### PR TITLE
feat: hide author email address via flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npx changelogen@latest [...args] [--dir <dir>]
 - `--preminor`: Bump as a semver-preminor version, can set id with string.
 - `--prepatch`: Bump as a semver-prepatch version, can set id with string.
 - `--prerelease`: Bump as a semver-prerelease version, can set id with string.
+- `--hideAuthorEmail`: Just show the author's GitHub handle without the email address.
 
 ### `changelogen gh release`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npx changelogen@latest [...args] [--dir <dir>]
 - `--preminor`: Bump as a semver-preminor version, can set id with string.
 - `--prepatch`: Bump as a semver-prepatch version, can set id with string.
 - `--prerelease`: Bump as a semver-prerelease version, can set id with string.
-- `--hideAuthorEmail`: Just show the author's GitHub handle without the email address.
+- `--hideAuthorEmail`: Do not include author email in changelog if github username cannot be found.
 
 ### `changelogen gh release`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ export interface ChangelogConfig {
     tagBody?: string;
   };
   excludeAuthors: string[];
+  hideAuthorEmail?: boolean;
 }
 
 export type ResolvedChangelogConfig = Omit<ChangelogConfig, "repo"> & {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -94,7 +94,7 @@ export async function generateMarkDown(
         const _email = [...i.email].find(
           (e) => !e.includes("noreply.github.com")
         );
-        const email = _email ? `<${_email}>` : "";
+        const email = config.hideAuthorEmail !== true && _email ? `<${_email}>` : "";
         const github = i.github
           ? `([@${i.github}](https://github.com/${i.github}))`
           : "";

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -94,7 +94,8 @@ export async function generateMarkDown(
         const _email = [...i.email].find(
           (e) => !e.includes("noreply.github.com")
         );
-        const email = config.hideAuthorEmail !== true && _email ? `<${_email}>` : "";
+        const email =
+          config.hideAuthorEmail !== true && _email ? `<${_email}>` : "";
         const github = i.github
           ? `([@${i.github}](https://github.com/${i.github}))`
           : "";


### PR DESCRIPTION
Add a new flag which allows to hide the email addresses for authors.

This PR resolves #246.