### PR TITLE
fix: release version regex supporting pre versions

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -186,5 +186,6 @@ function groupBy(items: any[], key: string) {
   return groups;
 }
 
-const CHANGELOG_RELEASE_HEAD_RE = /^#{2,}\s+.*(v?(\d+\.\d+\.\d+(-(rc\.)?\d+)?)).*$/gm;
+const CHANGELOG_RELEASE_HEAD_RE =
+  /^#{2,}\s+.*(v?(\d+\.\d+\.\d+(-(rc\.)?\d+)?)).*$/gm;
 const VERSION_RE = /^v?(\d+\.\d+\.\d+(-(rc\.)?\d+)?)$/;

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -185,5 +185,5 @@ function groupBy(items: any[], key: string) {
   return groups;
 }
 
-const CHANGELOG_RELEASE_HEAD_RE = /^#{2,}\s+.*(v?(\d+\.\d+\.\d+)).*$/gm;
-const VERSION_RE = /^v?(\d+\.\d+\.\d+)$/;
+const CHANGELOG_RELEASE_HEAD_RE = /^#{2,}\s+.*(v?(\d+\.\d+\.\d+(-(rc\.)?\d+)?)).*$/gm;
+const VERSION_RE = /^v?(\d+\.\d+\.\d+(-(rc\.)?\d+)?)$/;

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -187,5 +187,6 @@ function groupBy(items: any[], key: string) {
 }
 
 const CHANGELOG_RELEASE_HEAD_RE =
-  /^#{2,}\s+.*(v?(\d+\.\d+\.\d+(-(rc\.)?\d+)?)).*$/gm;
-const VERSION_RE = /^v?(\d+\.\d+\.\d+(-(rc\.)?\d+)?)$/;
+  /^#{2,}\s+.*(v?(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)).*$/gm;
+
+const VERSION_RE = /^v?(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)$/;


### PR DESCRIPTION
Resolves #258

Short hint:
Changelogen GitHub release creation does not support pre-release versions like `v1.0.0-rc.0` or `v1.0.0-0`.
Strangely, it can bump a version to something like this, which is then is not supported during GitHub release creation.