### PR TITLE
fix: pass `cwd` in more places before running commands

### DIFF
--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -29,7 +29,7 @@ export default async function defaultMain(args: Argv) {
   });
 
   if (args.clean) {
-    const dirty = await getCurrentGitStatus();
+    const dirty = await getCurrentGitStatus(cwd);
     if (dirty) {
       consola.error("Working directory is not clean.");
       process.exit(1);
@@ -39,7 +39,7 @@ export default async function defaultMain(args: Argv) {
   const logger = consola.create({ stdout: process.stderr });
   logger.info(`Generating changelog for ${config.from || ""}...${config.to}`);
 
-  const rawCommits = await getGitDiff(config.from, config.to);
+  const rawCommits = await getGitDiff(config.from, config.to, config.cwd);
 
   // Parse commits as conventional commits
   const commits = parseCommits(rawCommits, config)

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,11 +102,11 @@ export async function resolveChangelogConfig(
   cwd: string
 ) {
   if (!config.from) {
-    config.from = await getLastGitTag();
+    config.from = await getLastGitTag(cwd);
   }
 
   if (!config.to) {
-    config.to = await getCurrentGitRef();
+    config.to = await getCurrentGitRef(cwd);
   }
 
   if (config.output) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -27,41 +27,43 @@ export interface GitCommit extends RawGitCommit {
   isBreaking: boolean;
 }
 
-export async function getLastGitTag() {
+export async function getLastGitTag(cwd?: string) {
   try {
-    return execCommand("git describe --tags --abbrev=0")?.split("\n").at(-1);
+    return execCommand("git describe --tags --abbrev=0", cwd)?.split("\n").at(-1);
   } catch {
     // Ignore
   }
 }
 
-export function getCurrentGitBranch() {
-  return execCommand("git rev-parse --abbrev-ref HEAD");
+export function getCurrentGitBranch(cwd?: string) {
+  return execCommand("git rev-parse --abbrev-ref HEAD", cwd);
 }
 
-export function getCurrentGitTag() {
-  return execCommand("git tag --points-at HEAD");
+export function getCurrentGitTag(cwd?: string) {
+  return execCommand("git tag --points-at HEAD", cwd);
 }
 
-export function getCurrentGitRef() {
-  return getCurrentGitTag() || getCurrentGitBranch();
+export function getCurrentGitRef(cwd?: string) {
+  return getCurrentGitTag(cwd) || getCurrentGitBranch(cwd);
 }
 
 export function getGitRemoteURL(cwd: string, remote = "origin") {
-  return execCommand(`git --work-tree="${cwd}" remote get-url "${remote}"`);
+  return execCommand(`git --work-tree="${cwd}" remote get-url "${remote}"`, cwd);
 }
 
-export async function getCurrentGitStatus() {
-  return execCommand("git status --porcelain");
+export async function getCurrentGitStatus(cwd?: string) {
+  return execCommand("git status --porcelain", cwd);
 }
 
 export async function getGitDiff(
   from: string | undefined,
-  to = "HEAD"
+  to = "HEAD",
+  cwd?: string
 ): Promise<RawGitCommit[]> {
   // https://git-scm.com/docs/pretty-formats
   const r = execCommand(
-    `git --no-pager log "${from ? `${from}...` : ""}${to}" --pretty="----%n%s|%h|%an|%ae%n%b" --name-status`
+    `git --no-pager log "${from ? `${from}...` : ""}${to}" --pretty="----%n%s|%h|%an|%ae%n%b" --name-status`,
+    cwd
   );
   return r
     .split("----\n")

--- a/src/git.ts
+++ b/src/git.ts
@@ -29,7 +29,9 @@ export interface GitCommit extends RawGitCommit {
 
 export async function getLastGitTag(cwd?: string) {
   try {
-    return execCommand("git describe --tags --abbrev=0", cwd)?.split("\n").at(-1);
+    return execCommand("git describe --tags --abbrev=0", cwd)
+      ?.split("\n")
+      .at(-1);
   } catch {
     // Ignore
   }
@@ -48,7 +50,10 @@ export function getCurrentGitRef(cwd?: string) {
 }
 
 export function getGitRemoteURL(cwd: string, remote = "origin") {
-  return execCommand(`git --work-tree="${cwd}" remote get-url "${remote}"`, cwd);
+  return execCommand(
+    `git --work-tree="${cwd}" remote get-url "${remote}"`,
+    cwd
+  );
 }
 
 export async function getCurrentGitStatus(cwd?: string) {

--- a/src/package.ts
+++ b/src/package.ts
@@ -54,5 +54,5 @@ export async function npmPublish(config: ChangelogConfig) {
     args.push("--provenance");
   }
 
-  return execCommand(`npm publish ${args.join(" ")}`);
+  return execCommand(`npm publish ${args.join(" ")}`, config.cwd);
 }


### PR DESCRIPTION
noticed when running `changelogen` programmatically for a new feature in nuxt/ecosystem-ci - some commands respected the `cwd` but others did not.