### PR TITLE
fix: fix type of changelog config types

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import type { RepoConfig, RepoProvider } from "./repo";
 
 export interface ChangelogConfig {
   cwd: string;
-  types: Record<string, { title: string; semver?: SemverBumpType }>;
+  types: Record<string, { title: string; semver?: SemverBumpType } | boolean>;
   scopeMap: Record<string, string>;
   repo?: RepoConfig | string;
   tokens: Partial<Record<RepoProvider, string>>;


### PR DESCRIPTION
Hello!

In order not to include certain types of commits in changelog, you can pass the value `false`. 

```ts
// changelog.config.ts
import type { ChangelogConfig } from 'changelogen'

export default {
  types: {
    perf: {
      title: '🏎 Performance Improvements',
    },
    fix: {
      title: '🐞 Bug Fixes',
    },
    feat: {
      title: '🚀 Features',
    },
    refactor: false,
  },
  templates: {
    commitMessage: 'build: publish v{{newVersion}}',
  },
} satisfies Partial<ChangelogConfig>

```

This works, but errors occur when used in TypeScript config. This pullquest fixes the types of types.