### PR TITLE
feat: add repoType config option and improve Git URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# changelogen
+> # fork from [changelogen](https://github.com/unjs/changelogen)
+> ## Because we need to use the [282](https://github.com/unjs/changelogen/pull/282)
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "changelogen",
-  "version": "0.6.2",
+  "name": "@fixpkg/changelogen",
+  "version": "0.0.1",
   "description": "Generate Beautiful Changelogs using Conventional Commits",
-  "repository": "unjs/changelogen",
+  "repository": "duowb/changelogen",
   "license": "MIT",
   "sideEffects": false,
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export interface ChangelogConfig {
   noAuthors: boolean;
   excludeAuthors: string[];
   hideAuthorEmail?: boolean;
+  repoType?: RepoProvider | (string & {});
 }
 
 export type ResolvedChangelogConfig = Omit<ChangelogConfig, "repo"> & {
@@ -75,6 +76,7 @@ const getDefaultConfig = () =>
     },
     excludeAuthors: [],
     noAuthors: false,
+    repoType: "github",
   };
 
 export async function loadChangelogConfig(
@@ -117,11 +119,11 @@ export async function resolveChangelogConfig(
   }
 
   if (!config.repo) {
-    config.repo = await resolveRepoConfig(cwd);
+    config.repo = await resolveRepoConfig(cwd, config.repoType);
   }
 
   if (typeof config.repo === "string") {
-    config.repo = getRepoConfig(config.repo);
+    config.repo = getRepoConfig(config.repo, config.repoType);
   }
 
   return config as ResolvedChangelogConfig;


### PR DESCRIPTION
- Add optional repoType field to ChangelogConfig interface
- Support custom repository provider types beyond default detection
- Add convertGitUrlToStandard function for robust Git URL conversion
- Replace baseUrl function with url field in RepoConfig
- Improve SSH and HTTP/HTTPS URL format handling
- Add comprehensive URL validation and error handling

Why you need this feature?

Because we use git repositories with ip and port addresses. /(ㄒoㄒ)/~~

`http://ip:port`


<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
