### PR TITLE
feat: support commit body in breaking changes section

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export interface ChangelogConfig {
   noAuthors: boolean;
   excludeAuthors: string[];
   hideAuthorEmail?: boolean;
+  breakingChangesIncludeBody?: boolean;
 }
 
 export type ResolvedChangelogConfig = Omit<ChangelogConfig, "repo"> & {


### PR DESCRIPTION

Closes #112 

Add a new boolean configuration property `breakingChangesIncludeBody` to allow using the BREAKING CHANGE: text instead of the commit title to generate the `Breaking Changes` section.

**Commit example**
```sh
feat: add some breaking changes

BREAKING CHANGE: Here will be short info on how to migrate
```

### Current behaviour
Currently, the Breaking Changes section contains duplicate entries that don’t make sense. Ideally, it should display the `BREAKING CHANGE:` message from the commit body.

```md
## v0.10.2...next

[compare changes](https://github.com/.../v0.10.2...next)

### 🚀 Enhancements

- ⚠️  Add some breaking changes ([...](https://github.com/.../commit/...))

#### ⚠️ Breaking Changes

- ⚠️  Add some breaking changes ([...](https://github.com/.../commit/...))

### ❤️ Contributors

- Vadym Bulakh ([@vad1ym](https://github.com/vad1ym))
```

### Desired behaviour

The Breaking Changes section should display the `BREAKING CHANGE:` commit description instead of duplicating the commit title.

```md
## v0.10.2...next

[compare changes](https://github.com/.../v0.10.2...next)

### 🚀 Enhancements

- ⚠️  Add some breaking changes ([...](https://github.com/.../commit/...))

#### ⚠️ Breaking Changes

- Here will be short info on how to migrate

### ❤️ Contributors

- Vadym Bulakh ([@vad1ym](https://github.com/vad1ym))
```