### PR TITLE
feat: add PR author fallback for contributor tagging

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -116,6 +116,21 @@ export function githubNewReleaseURL(
   }&title=v${release.version}&body=${encodeURIComponent(release.body)}`;
 }
 
+export async function getPullRequestAuthorLogin(
+  config: ResolvedChangelogConfig,
+  prNumber: number
+): Promise<string | undefined> {
+  try {
+    const pr = await githubFetch(
+      config,
+      `/repos/${config.repo.repo}/pulls/${prNumber}`
+    );
+    return pr?.user?.login;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function resolveGithubToken(config: ResolvedChangelogConfig) {
   const env =
     process.env.CHANGELOGEN_TOKENS_GITHUB ||

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { loadChangelogConfig } from "../src";
+import {
+  getGithubChangelog,
+  getGithubReleaseByTag,
+  getPullRequestAuthorLogin,
+  githubNewReleaseURL,
+  listGithubReleases,
+  resolveGithubToken,
+  syncGithubRelease,
+} from "../src/github";
+
+vi.mock("ofetch", () => ({
+  $fetch: vi.fn(),
+}));
+
+describe("github", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("getPullRequestAuthorLogin should return undefined when API call fails", async () => {
+    const { $fetch } = await import("ofetch");
+    vi.mocked($fetch).mockRejectedValueOnce(new Error("API Error"));
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const result = await getPullRequestAuthorLogin(config, 123);
+    expect(result).toBeUndefined();
+  });
+
+  test("listGithubReleases should fetch releases with pagination", async () => {
+    const { $fetch } = await import("ofetch");
+    const mockReleases = [{ tag_name: "v1.0.0" }, { tag_name: "v0.9.0" }];
+    vi.mocked($fetch).mockResolvedValueOnce(mockReleases);
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const releases = await listGithubReleases(config);
+    expect(releases).toEqual(mockReleases);
+    expect($fetch).toHaveBeenCalledWith("/repos/test/repo/releases", {
+      baseURL: "https://api.github.com",
+      headers: {
+        "x-github-api-version": "2022-11-28",
+        authorization: undefined,
+      },
+      query: { per_page: 100 },
+    });
+  });
+
+  test("getGithubReleaseByTag should fetch specific release", async () => {
+    const { $fetch } = await import("ofetch");
+    const mockRelease = { tag_name: "v1.0.0", body: "Release notes" };
+    vi.mocked($fetch).mockResolvedValueOnce(mockRelease);
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const release = await getGithubReleaseByTag(config, "v1.0.0");
+    expect(release).toEqual(mockRelease);
+    expect($fetch).toHaveBeenCalledWith(
+      "/repos/test/repo/releases/tags/v1.0.0",
+      {
+        baseURL: "https://api.github.com",
+        headers: {
+          "x-github-api-version": "2022-11-28",
+          authorization: undefined,
+        },
+      }
+    );
+  });
+
+  test("syncGithubRelease should create new release when none exists", async () => {
+    const { $fetch } = await import("ofetch");
+    vi.mocked($fetch).mockRejectedValueOnce(new Error("Not found"));
+    vi.mocked($fetch).mockResolvedValueOnce({ id: "new-release-id" });
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+      tokens: { github: "test-token" },
+    });
+
+    const result = await syncGithubRelease(config, {
+      version: "1.0.0",
+      body: "Release notes",
+    });
+
+    expect(result).toEqual({
+      status: "created",
+      id: "new-release-id",
+    });
+  });
+
+  test("syncGithubRelease should return manual URL when no token", async () => {
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const result = await syncGithubRelease(config, {
+      version: "1.0.0",
+      body: "Release notes",
+    });
+
+    expect(result).toEqual({
+      status: "manual",
+      url: expect.stringContaining("/releases/new?tag=v1.0.0"),
+    });
+  });
+
+  test("githubNewReleaseURL should generate correct URL with encoded body", async () => {
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const url = githubNewReleaseURL(config, {
+      version: "1.0.0",
+      body: "Release notes with spaces & special chars",
+    });
+
+    expect(url).toBe(
+      "https://github.com/test/repo/releases/new?tag=v1.0.0&title=v1.0.0&body=Release%20notes%20with%20spaces%20%26%20special%20chars"
+    );
+  });
+
+  test("GitHub Enterprise API URLs should be handled correctly", async () => {
+    const { $fetch } = await import("ofetch");
+    vi.mocked($fetch).mockResolvedValueOnce([]);
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      tokens: { github: "test-token" },
+      // Override the domain to simulate enterprise GitHub
+      repo: {
+        domain: "github.enterprise.com",
+        repo: "test/repo",
+      },
+    });
+
+    await listGithubReleases(config);
+
+    expect($fetch).toHaveBeenCalledWith("/repos/test/repo/releases", {
+      baseURL: "https://github.enterprise.com/api/v3",
+      headers: {
+        "x-github-api-version": "2022-11-28",
+        authorization: "Bearer test-token",
+      },
+      query: { per_page: 100 },
+    });
+  });
+
+  test("getGithubChangelog should fetch changelog from main branch", async () => {
+    const { $fetch } = await import("ofetch");
+    const mockChangelog = "# Changelog";
+    vi.mocked($fetch).mockResolvedValueOnce(mockChangelog);
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const changelog = await getGithubChangelog(config);
+    expect(changelog).toBe(mockChangelog);
+    expect($fetch).toHaveBeenCalledWith(
+      "https://raw.githubusercontent.com/test/repo/main/CHANGELOG.md",
+      expect.any(Object)
+    );
+  });
+
+  test("syncGithubRelease should handle update errors", async () => {
+    const { $fetch } = await import("ofetch");
+    vi.mocked($fetch).mockResolvedValueOnce({ id: "existing-id" });
+    vi.mocked($fetch).mockRejectedValueOnce(new Error("Update failed"));
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+      tokens: { github: "test-token" },
+    });
+
+    const result = await syncGithubRelease(config, {
+      version: "1.0.0",
+      body: "Release notes",
+    });
+
+    expect(result).toEqual({
+      status: "manual",
+      error: expect.any(Error),
+      url: expect.stringContaining("/releases/new?tag=v1.0.0"),
+    });
+  });
+
+  test("resolveGithubToken should handle environment variables", async () => {
+    const originalEnv = process.env;
+    process.env = { ...originalEnv, GITHUB_TOKEN: "test-token" };
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const token = await resolveGithubToken(config);
+    expect(token).toBe("test-token");
+
+    process.env = originalEnv;
+  });
+
+  test("resolveGithubToken should try multiple environment variables", async () => {
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      CHANGELOGEN_TOKENS_GITHUB: "changelogen-token",
+      GITHUB_TOKEN: "github-token",
+      GH_TOKEN: "gh-token",
+    };
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const token = await resolveGithubToken(config);
+    expect(token).toBe("changelogen-token"); // Should use first available token
+
+    process.env = originalEnv;
+  });
+
+  test("resolveGithubToken should return undefined when no token sources available", async () => {
+    const originalEnv = process.env;
+    process.env = { ...originalEnv }; // Clear token env vars
+    delete process.env.CHANGELOGEN_TOKENS_GITHUB;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+
+    const config = await loadChangelogConfig(process.cwd(), {
+      repo: "test/repo",
+    });
+
+    const token = await resolveGithubToken(config);
+    expect(token).toBeUndefined();
+
+    process.env = originalEnv;
+  });
+});

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,6 +1,36 @@
 import { promises as fsp } from "node:fs";
 import { describe, expect, test } from "vitest";
-import { parseChangelogMarkdown } from "../src";
+import { generateMarkDown, parseChangelogMarkdown } from "../src";
+import type { ResolvedChangelogConfig } from "../src/config";
+import type { GitCommit, GitCommitAuthor } from "../src/git";
+
+const baseConfig: ResolvedChangelogConfig = {
+  cwd: "/test",
+  from: "1.0.0",
+  to: "2.0.0",
+  newVersion: "2.0.0",
+  output: "CHANGELOG.md",
+  types: {
+    feat: { title: "🚀 Enhancements" },
+    fix: { title: "🩹 Fixes" },
+    docs: { title: "📖 Documentation" },
+    chore: { title: "🏡 Chore" },
+  },
+  publish: {},
+  repo: {
+    provider: "github",
+    domain: "github.com",
+    repo: "test/repo",
+  },
+  tokens: {},
+  scopeMap: {},
+  templates: {
+    tagBody: "v{{newVersion}}",
+  },
+  excludeAuthors: [],
+  noAuthors: false,
+  hideAuthorEmail: false,
+};
 
 describe("markdown", () => {
   test("should parse markdown", async () => {
@@ -55,5 +85,161 @@ describe("markdown", () => {
         ],
       }
     `);
+  });
+
+  test("should exclude bot users from contributors", async () => {
+    const commits: GitCommit[] = [
+      {
+        shortHash: "abc123",
+        message: "feat: auto update",
+        author: {
+          name: "renovate[bot]",
+          email: "bot@renovateapp.com",
+        },
+        type: "feat",
+        scope: "",
+        description: "auto update",
+        body: "",
+        isBreaking: false,
+        references: [],
+        authors: [],
+      },
+    ];
+
+    const markdown = await generateMarkDown(commits, baseConfig);
+    expect(markdown).not.toContain("[bot]");
+    expect(markdown).not.toContain("### ❤️ Contributors");
+  });
+
+  test("should exclude noreply.github.com emails from contributors", async () => {
+    const commits: GitCommit[] = [
+      {
+        shortHash: "abc123",
+        message: "feat: add feature",
+        author: {
+          name: "test user",
+          email: "test@noreply.github.com",
+        },
+        type: "feat",
+        scope: "",
+        description: "add feature",
+        body: "",
+        isBreaking: false,
+        references: [],
+        authors: [],
+      },
+      {
+        shortHash: "def456",
+        message: "fix: fix bug",
+        author: {
+          name: "test user",
+          email: "real@example.com",
+        },
+        type: "fix",
+        scope: "",
+        description: "fix bug",
+        body: "",
+        isBreaking: false,
+        references: [],
+        authors: [],
+      },
+    ];
+
+    const markdown = await generateMarkDown(commits, baseConfig);
+    expect(markdown).toContain("real@example.com");
+    expect(markdown).not.toContain("noreply.github.com");
+  });
+
+  test("should exclude authors based on excludeAuthors config", async () => {
+    const commits: GitCommit[] = [
+      {
+        shortHash: "abc123",
+        message: "feat: add feature",
+        author: {
+          name: "excluded user",
+          email: "excluded@example.com",
+        },
+        type: "feat",
+        scope: "",
+        description: "add feature",
+        body: "",
+        isBreaking: false,
+        references: [],
+        authors: [],
+      },
+      {
+        shortHash: "def456",
+        message: "fix: fix bug",
+        author: {
+          name: "included user",
+          email: "included@example.com",
+        },
+        type: "fix",
+        scope: "",
+        description: "fix bug",
+        body: "",
+        isBreaking: false,
+        references: [],
+        authors: [],
+      },
+    ];
+
+    const config = {
+      ...baseConfig,
+      excludeAuthors: ["excluded"],
+    };
+
+    const markdown = await generateMarkDown(commits, config);
+    expect(markdown).not.toContain("excluded user");
+    expect(markdown).toContain("Included User");
+  });
+
+  test("should not include contributors when noAuthors is true", async () => {
+    const commits: GitCommit[] = [
+      {
+        shortHash: "abc123",
+        message: "feat: add feature",
+        author: {
+          name: "test user",
+          email: "test@example.com",
+        },
+        type: "feat",
+        scope: "",
+        description: "add feature",
+        body: "",
+        isBreaking: false,
+        references: [],
+        authors: [],
+      },
+    ];
+
+    const config = {
+      ...baseConfig,
+      noAuthors: true,
+    };
+
+    const markdown = await generateMarkDown(commits, config);
+    expect(markdown).not.toContain("### ❤️ Contributors");
+  });
+
+  test("should handle commits without authors", async () => {
+    const commits: GitCommit[] = [
+      {
+        shortHash: "abc123",
+        message: "feat: add feature",
+        author: null as unknown as GitCommitAuthor,
+        type: "feat",
+        scope: "",
+        description: "add feature",
+        body: "",
+        isBreaking: false,
+        references: [],
+        authors: [],
+      },
+    ];
+
+    const markdown = await generateMarkDown(commits, baseConfig);
+    expect(markdown).toContain("- Add feature");
+    expect(markdown).not.toContain("### ❤️ Contributors");
   });
 });


### PR DESCRIPTION
Enhances contributor attribution by adding a fallback mechanism that uses GitHub PR author information when email-to-username resolution fails.

Resolves #116

## Changes
- Added `getPullRequestAuthorLogin()` function in `github.ts` to fetch PR author details
- Enhanced `generateMarkDown()` in `markdown.ts` with PR author fallback logic
- Added helper function `getAuthorPRNumber()` to extract PR numbers from commit references

## Benefits
- Better contributor attribution in changelogs
- Fallback mechanism for private email addresses
- No breaking changes to existing functionality

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contributor attribution for GitHub repositories by using the referenced pull request author when email-based identification is unavailable.
  - Contributors with bot accounts, noreply addresses, excluded names, or missing author data are handled more reliably.
  - Contributor sections are omitted when configured or when no eligible contributors are found.

- **Tests**
  - Expanded coverage for GitHub integration, release handling, author attribution, and contributor-list generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->