### PR TITLE
fix: increase max buffer size of git output

### DIFF
--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,5 +1,9 @@
 import { execSync } from "node:child_process";
 
 export function execCommand(cmd: string, cwd?: string) {
-  return execSync(cmd, { encoding: "utf8", cwd, maxBuffer: 10 * 1024 * 1024 /* 10 Mb */ }).trim();
+  return execSync(cmd, {
+    encoding: "utf8",
+    cwd,
+    maxBuffer: 1 * 1024 * 1024 /* 10 Mb */,
+  }).trim();
 }

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
 
 export function execCommand(cmd: string, cwd?: string) {
-  return execSync(cmd, { encoding: "utf8", cwd }).trim();
+  return execSync(cmd, { encoding: "utf8", cwd, maxBuffer: 10 * 1024 * 1024 /* 10 Mb */ }).trim();
 }

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -4,6 +4,6 @@ export function execCommand(cmd: string, cwd?: string) {
   return execSync(cmd, {
     encoding: "utf8",
     cwd,
-    maxBuffer: 1 * 1024 * 1024 /* 10 Mb */,
+    maxBuffer: 10 * 1024 * 1024 /* 10 Mb */,
   }).trim();
 }


### PR DESCRIPTION
we were encountering failures after merging in 1.x and 2.x commit history into nuxt main branch. this seems to be because of the default max buffer size (which is 200Kb).

this bumps the buffer size to 10Mb (we actually need 2Mb in nuxt, but this should offer some space)

for example (in another project where I used changelogen programmatically):

```
 ERROR  spawnSync /bin/sh ENOBUFS

    at Object.spawnSync (node:internal/child_process:1120:20)
    at spawnSync (node:child_process:910:24)
    at execSync (node:child_process:991:15)
    at execCommand (/Users/daniel/code/danielroe/rerun/node_modules/.pnpm/changelogen@0.6.2_magicast@0.3.5/node_modules/changelogen/dist/shared/changelogen.D-9f3HTX.mjs:14:10)
    at getGitDiff (/Users/daniel/code/danielroe/rerun/node_modules/.pnpm/changelogen@0.6.2_magicast@0.3.5/node_modules/changelogen/dist/shared/changelogen.D-9f3HTX.mjs:42:13)
    at getCommitsBetween (/Users/daniel/code/danielroe/rerun/src/commands/compare-branches.ts:44:30)
    at async Object.run (/Users/daniel/code/danielroe/rerun/src/commands/compare-branches.ts:213:27)
    at async runCommand (/Users/daniel/code/danielroe/rerun/node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:316:16)
    at async runCommand (/Users/daniel/code/danielroe/rerun/node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:307:11)
    at async runMain (/Users/daniel/code/danielroe/rerun/node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:445:7)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced command execution to handle larger output buffers and improve encoding consistency across different execution contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/changelogen/pull/303)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->