### PR TITLE
feat: add gh publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,31 @@ In order to manually sync a release, you can use `changelogen gh release`. It wi
 Usage:
 
 ```sh
-npx changelogen@latest gh release [all|versions...] [--dir] [--token]
+npx changelogen@latest gh release [all|versions...] [--dir] [--token] [--no-open]
 ```
 
 To enable this integration, make sure there is a valid `repository` field in `package.json` or `repo` is set in `.changelogenrc`.
 
 By default in unauthenticated mode, changelogen will open a browser link to make manual release. By providing github token, it can be automated.
+Use `--no-open` to prevent opening a browser and only print the link.
 
 - Using environment variables or `.env`, use `CHANGELOGEN_TOKENS_GITHUB` or `GITHUB_TOKEN` or `GH_TOKEN`
 - Using CLI args, use `--token <token>`
 - Using global configuration, put `tokens.github=<token>` inside `~/.changlogenrc`
 - Using [GitHub CLI](https://cli.github.com/) token when authenticated with `gh auth login`
+
+### `changelogen gh publish`
+
+Generate release notes from git commits (same format as `CHANGELOG.md`) and create or update a GitHub release without writing to `CHANGELOG.md`.
+
+Usage:
+
+```sh
+npx changelogen@latest gh publish [--tag] [--from] [--to] [--dir] [--token] [--dry] [--no-open]
+```
+
+By default, it uses the previous tag to the current tag (or `HEAD` if no tag) as the range.
+Use `--dry` to print the generated release notes without creating a GitHub release.
 
 ## Configuration
 

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -150,10 +150,14 @@ export default async function defaultMain(args: Argv) {
       execCommand("git push --follow-tags", cwd);
     }
     if (args.github !== false && config.repo?.provider === "github") {
-      await githubRelease(config, {
-        version: config.newVersion,
-        body: markdown.split("\n").slice(2).join("\n"),
-      });
+      await githubRelease(
+        config,
+        {
+          version: config.newVersion,
+          body: markdown.split("\n").slice(2).join("\n"),
+        },
+        { open: args.open !== false }
+      );
     }
   }
 

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -9,8 +9,13 @@ import {
   syncGithubRelease,
 } from "../github";
 import {
+  generateMarkDown,
+  getCurrentGitTag,
+  getGitDiff,
+  getPreviousGitTag,
   ResolvedChangelogConfig,
   loadChangelogConfig,
+  parseCommits,
   parseChangelogMarkdown,
 } from "..";
 
@@ -19,9 +24,17 @@ export default async function githubMain(args: Argv) {
   process.chdir(cwd);
 
   const [subCommand, ..._versions] = args._;
+  if (subCommand === "publish") {
+    await githubPublish(args, cwd);
+    return;
+  }
   if (subCommand !== "release") {
     consola.log(
-      "Usage: changelogen gh release [all|versions...] [--dir] [--token]"
+      [
+        "Usage:",
+        "  changelogen gh release [all|versions...] [--dir] [--token] [--no-open]",
+        "  changelogen gh publish [--tag] [--from] [--to] [--dir] [--token] [--dry] [--no-open]",
+      ].join("\n")
     );
     process.exit(1);
   }
@@ -85,16 +98,99 @@ export default async function githubMain(args: Argv) {
       );
       continue;
     }
-    await githubRelease(config, {
-      version: release.version,
-      body: release.body,
-    });
+    await githubRelease(
+      config,
+      {
+        version: release.version,
+        body: release.body,
+      },
+      { open: args.open !== false }
+    );
   }
+}
+
+async function githubPublish(args: Argv, cwd: string) {
+  const refTags =
+    getCurrentGitTag(cwd)
+      ?.split("\n")
+      .map((t) => t.trim())
+      .filter(Boolean) || [];
+  const tag =
+    (typeof args.tag === "string" && args.tag) ||
+    process.env.GITHUB_REF_NAME ||
+    refTags.find((t) => /^v?\d/.test(t)) ||
+    refTags[0];
+
+  const version = tag ? tag.replace(/^v/, "") : undefined;
+
+  let from: string | undefined;
+  if (typeof args.from === "string") {
+    from = args.from;
+  } else if (tag) {
+    from = await getPreviousGitTag(cwd, tag);
+  }
+
+  const to = typeof args.to === "string" ? args.to : tag || undefined;
+
+  const config = await loadChangelogConfig(cwd, {
+    from,
+    to,
+    newVersion: version,
+    noAuthors: args.noAuthors,
+    hideAuthorEmail: args.hideAuthorEmail,
+  });
+
+  if (config.repo?.provider !== "github") {
+    consola.error(
+      "This command is only supported for github repository provider."
+    );
+    process.exit(1);
+  }
+
+  if (args.token) {
+    config.tokens.github = args.token;
+  }
+
+  if (!config.newVersion) {
+    consola.error("Unable to resolve tag for release. Use --tag.");
+    process.exit(1);
+  }
+
+  const rawCommits = await getGitDiff(config.from, config.to, config.cwd);
+
+  const commits = parseCommits(rawCommits, config)
+    .map((c) => ({ ...c, type: c.type.toLowerCase() /* #198 */ }))
+    .filter(
+      (c) =>
+        config.types[c.type] &&
+        !(
+          c.type === "chore" &&
+          ["deps", "release"].includes(c.scope) &&
+          !c.isBreaking
+        )
+    );
+
+  const markdown = await generateMarkDown(commits, config);
+
+  if (args.dry) {
+    consola.log("\n\n" + markdown + "\n\n");
+    return;
+  }
+
+  await githubRelease(
+    config,
+    {
+      version: config.newVersion,
+      body: markdown,
+    },
+    { open: args.open !== false }
+  );
 }
 
 export async function githubRelease(
   config: ResolvedChangelogConfig,
-  release: { version: string; body: string }
+  release: { version: string; body: string },
+  options: { open?: boolean } = {}
 ) {
   if (!config.tokens.github) {
     config.tokens.github = await resolveGithubToken(config).catch(
@@ -113,6 +209,14 @@ export async function githubRelease(
     if (result.error) {
       consola.error(result.error);
       process.exitCode = 1;
+    }
+    if (options.open === false) {
+      consola.info(
+        `Open this link to manually create a release: \n` +
+          colors.underline(colors.cyan(result.url)) +
+          "\n"
+      );
+      return;
     }
     const open = await import("open").then((r) => r.default);
     await open(result.url)

--- a/src/git.ts
+++ b/src/git.ts
@@ -37,6 +37,38 @@ export async function getLastGitTag(cwd?: string) {
   }
 }
 
+export async function getPreviousGitTag(cwd?: string, ref?: string) {
+  try {
+    if (ref) {
+      return execCommand(`git describe --tags --abbrev=0 "${ref}^"`, cwd)
+        ?.split("\n")
+        .at(-1);
+    }
+  } catch {
+    // Ignore
+  }
+
+  try {
+    const tags = execCommand("git tag --sort=-v:refname", cwd)
+      .split("\n")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    if (tags.length === 0) {
+      return;
+    }
+    if (ref) {
+      const index = tags.indexOf(ref);
+      if (index !== -1 && index + 1 < tags.length) {
+        return tags[index + 1];
+      }
+      return tags.find((t) => t !== ref);
+    }
+    return tags[0];
+  } catch {
+    // Ignore
+  }
+}
+
 export function getCurrentGitBranch(cwd?: string) {
   return execCommand("git rev-parse --abbrev-ref HEAD", cwd);
 }


### PR DESCRIPTION
Currently, I use changelogen to generate changelog.md, as well as [changelogithub](https://github.com/antfu/changelogithub) to create a release on GitHub using Github Actions. 

It would be great to move the changelogithub logic to the main repository. We already have an issue about this:
https://github.com/antfu/changelogithub/issues/4

In my workflow, it looks like this. I run changelogen to generate the changelog: 

```json
{
  "scripts": {
    "release:version": "changelogen --output changelog.md --release --no-commit --no-tag",
  }
}
```

And after pushing, I create a release in Github Actions:

```yml
      - name: Create GitHub Release
        run: pnpm run ci:changelog
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

You can see examples of workflows in my repositories:
https://github.com/azat-io/actions-up
https://github.com/azat-io/eslint-plugin-perfectionist

This PR adds a new command, `changelogen gh publish`, which generates release notes using the existing changelog logic and creates/updates a GitHub Release in CI without writing `CHANGELOG.md`. It also adds `--no-open` to avoid opening a browser and only print the manual release URL.