### PR TITLE
refactor: remove extra space after breaking change emoji

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -141,7 +141,7 @@ function formatCommit(commit: GitCommit, config: ResolvedChangelogConfig) {
   return (
     "- " +
     (commit.scope ? `**${commit.scope.trim()}:** ` : "") +
-    (commit.isBreaking ? "⚠️  " : "") +
+    (commit.isBreaking ? "⚠️ " : "") +
     upperFirst(commit.description) +
     formatReferences(commit.references, config)
   );

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -463,7 +463,7 @@ describe("git", () => {
       ### 🩹 Fixes
 
       - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
-      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - **scope:** ⚠️ Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### 🏡 Chore
 
@@ -476,7 +476,7 @@ describe("git", () => {
 
       #### ⚠️ Breaking Changes
 
-      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - **scope:** ⚠️ Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### ❤️ Contributors
 


### PR DESCRIPTION
Fixes #309

The breaking change emoji had two spaces after it (`⚠️  `) instead of one (`⚠️ `), causing an extra space in the generated changelog output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in markdown for breaking-change notices (reduced extra space after the warning icon), improving consistency in generated commit entries.
* **Tests**
  * Updated tests to match the revised breaking-change markdown spacing so snapshots and expected outputs remain aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->