### PR TITLE
fix(repo): preserve port number when parsing remote URLs

### DIFF
--- a/src/repo.ts
+++ b/src/repo.ts
@@ -109,7 +109,7 @@ export function getRepoConfig(repoUrl = ""): RepoConfig {
     domain =
       provider in providerToDomain ? providerToDomain[provider] : provider;
   } else if (url) {
-    domain = url.hostname;
+    domain = url.host;
     const paths = url.pathname.split("/");
     repo = paths
       .slice(1)

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -115,7 +115,7 @@ export function getRepoConfig(repoUrl = ""): RepoConfig {
       .slice(1)
       .join("/")
       .replace(/\.git$/, "");
-    provider = domainToProvider[domain];
+    provider = domainToProvider[url.hostname];
   } else if (m.repo) {
     repo = m.repo;
     provider = "github";

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -84,6 +84,14 @@ describe("repo", () => {
             repo: "account/project/sub1/sub2/myproject",
           },
         },
+        {
+          input: "http://192.168.0.1:30080/owner/repo.git",
+          output: {
+            domain: "192.168.0.1:30080",
+            provider: undefined,
+            repo: "owner/repo",
+          },
+        },
       ])("url=$input should return RepoConfig", ({ input, output }) => {
         expect(getRepoConfig(input)).toEqual(output);
       });

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -92,6 +92,14 @@ describe("repo", () => {
             repo: "owner/repo",
           },
         },
+        {
+          input: "https://github.com:443/unjs/changelogen.git",
+          output: {
+            domain: "github.com",
+            provider: "github",
+            repo: "unjs/changelogen",
+          },
+        },
       ])("url=$input should return RepoConfig", ({ input, output }) => {
         expect(getRepoConfig(input)).toEqual(output);
       });


### PR DESCRIPTION
Use `url.host` instead of `url.hostname` in `getRepoConfig` so that a remote URL like `http://192.168.0.1:30080/owner/repo.git` keeps the port in the resolved domain, producing correct compare and reference links.

Closes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository domain parsing now preserves host plus port from repository URLs, improving handling of repos accessed via non-standard ports.
* **Tests**
  * Added a test case covering repository URLs that use an IP address with a port to validate parsing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/changelogen/pull/321)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->