### PR TITLE
fix: use correct path for Bitbucket hashes

### DIFF
--- a/src/repo.ts
+++ b/src/repo.ts
@@ -20,7 +20,7 @@ const providerToRefSpec: Record<
   gitlab: { "pull-request": "merge_requests", hash: "commit", issue: "issues" },
   bitbucket: {
     "pull-request": "pull-requests",
-    hash: "commit",
+    hash: "commits",
     issue: "issues",
   },
 };

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -616,7 +616,7 @@ describe("git", () => {
     };
 
     expect(formatReference({ type: "hash", value: "3828bda" }, bitbucket)).toBe(
-      "[3828bda](https://bitbucket.org/unjs/changelogen/commit/3828bda)"
+      "[3828bda](https://bitbucket.org/unjs/changelogen/commits/3828bda)"
     );
     expect(
       formatReference({ type: "pull-request", value: "#123" }, bitbucket)


### PR DESCRIPTION
Fixes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Bitbucket commit hash links to use the correct URL path format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/changelogen/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->