### PR TITLE
fix: correct breaking change spacing and Bitbucket commit URLs

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -141,7 +141,7 @@ function formatCommit(commit: GitCommit, config: ResolvedChangelogConfig) {
   return (
     "- " +
     (commit.scope ? `**${commit.scope.trim()}:** ` : "") +
-    (commit.isBreaking ? "⚠️  " : "") +
+    (commit.isBreaking ? "⚠️ " : "") +
     upperFirst(commit.description) +
     formatReferences(commit.references, config)
   );

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -20,7 +20,7 @@ const providerToRefSpec: Record<
   gitlab: { "pull-request": "merge_requests", hash: "commit", issue: "issues" },
   bitbucket: {
     "pull-request": "pull-requests",
-    hash: "commit",
+    hash: "commits",
     issue: "issues",
   },
 };

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -463,7 +463,7 @@ describe("git", () => {
       ### 🩹 Fixes
 
       - Consider docs and refactor as semver patch for bump ([648ccf1](https://github.com/unjs/changelogen/commit/648ccf1))
-      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - **scope:** ⚠️ Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### 🏡 Chore
 
@@ -476,7 +476,7 @@ describe("git", () => {
 
       #### ⚠️ Breaking Changes
 
-      - **scope:** ⚠️  Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
+      - **scope:** ⚠️ Breaking change example, close #123 ([#134](https://github.com/unjs/changelogen/pull/134), [#123](https://github.com/unjs/changelogen/issues/123))
 
       ### ❤️ Contributors
 
@@ -616,7 +616,7 @@ describe("git", () => {
     };
 
     expect(formatReference({ type: "hash", value: "3828bda" }, bitbucket)).toBe(
-      "[3828bda](https://bitbucket.org/unjs/changelogen/commit/3828bda)"
+      "[3828bda](https://bitbucket.org/unjs/changelogen/commits/3828bda)"
     );
     expect(
       formatReference({ type: "pull-request", value: "#123" }, bitbucket)


### PR DESCRIPTION
## Summary

This PR fixes two small but impactful bugs in the changelog generation pipeline:

### Fix 1: Extra space after breaking change emoji (#309)
- **File:** 
- **Problem:** The breaking change emoji  was followed by two spaces instead of one, causing inconsistent formatting in generated changelogs.
- **Change:**  → 

### Fix 2: Bitbucket commit URL path (#322)
- **File:** 
- **Problem:** Bitbucket uses the plural path  (not ) for commit hash URLs. Links to Bitbucket commits in generated changelogs were broken.
- **Change:**  →  for the  provider mapping.

### Test Updates
- Updated inline snapshot in  to match corrected emoji spacing.
- Updated Bitbucket URL assertion to expect  path.

All 23 tests pass after these changes.

## Checklist
- [x] Bug fix (non-breaking change)
- [x] Tests updated and passing
- [x] No new dependencies

Closes #309
Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Bitbucket commit links so references now open the intended commit pages.
  - Improved Markdown formatting for breaking-change references by removing unintended extra spacing after the warning icon.
  - Updated generated reference output to consistently match the corrected formatting and link paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->