### PR TITLE
feat: support filtering commits by paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npx changelogen@latest [...args] [--dir <dir>]
 - `--from`: Start commit reference. When not provided, **latest git tag** will be used as default.
 - `--to`: End commit reference. When not provided, **latest commit in HEAD** will be used as default.
 - `--dir`: Path to git repository. When not provided, **current working directory** will be used as as default.
+- `--path`: Only consider commits that modified this path, relative to the repository root (example: `--path packages/foo`). Can be repeated to include multiple paths. Useful for monorepos.
 - `--clean`: Determine if the working directory is clean and if it is not clean, exit.
 - `--output`: Changelog file name to create or update. Defaults to `CHANGELOG.md` and resolved relative to dir. Use `--no-output` to write to console only.
 - `--noAuthors`: Skip contributors section in changelog.

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -23,6 +23,7 @@ export default async function defaultMain(args: Argv) {
   const config = await loadChangelogConfig(cwd, {
     from: args.from,
     to: args.to,
+    paths: args.path,
     output: args.output,
     newVersion: typeof args.r === "string" ? args.r : undefined,
     noAuthors: args.noAuthors,
@@ -40,7 +41,12 @@ export default async function defaultMain(args: Argv) {
   const logger = consola.create({ stdout: process.stderr });
   logger.info(`Generating changelog for ${config.from || ""}...${config.to}`);
 
-  const rawCommits = await getGitDiff(config.from, config.to, config.cwd);
+  const rawCommits = await getGitDiff(
+    config.from,
+    config.to,
+    config.cwd,
+    config.paths
+  );
 
   // Parse commits as conventional commits
   const commits = parseCommits(rawCommits, config)

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,10 @@ export interface ChangelogConfig {
   tokens: Partial<Record<RepoProvider, string>>;
   from: string;
   to: string;
+  /**
+   * Only consider commits that modified these paths (relative to the repository root).
+   */
+  paths?: string | string[];
   newVersion?: string;
   signTags?: boolean;
   output: string | boolean;

--- a/src/git.ts
+++ b/src/git.ts
@@ -63,11 +63,17 @@ export async function getCurrentGitStatus(cwd?: string) {
 export async function getGitDiff(
   from: string | undefined,
   to = "HEAD",
-  cwd?: string
+  cwd?: string,
+  paths?: string | string[]
 ): Promise<RawGitCommit[]> {
+  const pathspec = [paths]
+    .flat()
+    .filter(Boolean)
+    .map((path) => ` "${path}"`)
+    .join("");
   // https://git-scm.com/docs/pretty-formats
   const r = execCommand(
-    `git --no-pager log "${from ? `${from}...` : ""}${to}" --pretty="----%n%s|%h|%an|%ae%n%b" --name-status`,
+    `git --no-pager log "${from ? `${from}...` : ""}${to}" --pretty="----%n%s|%h|%an|%ae%n%b" --name-status${pathspec ? ` --${pathspec}` : ""}`,
     cwd
   );
   return r

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -21,6 +21,34 @@ describe("git", () => {
     );
   });
 
+  test("getGitDiff should support paths filter", async () => {
+    const COMMIT_INITIAL = "4554fc49265ac532b14c89cec15e7d21bb55d48b";
+    const COMMIT_VER002 = "38d7ba15dccc3a44931bf8bf0abaa0d4d96603eb";
+
+    // filtering by the repository root includes all commits
+    expect(
+      (await getGitDiff(COMMIT_INITIAL, COMMIT_VER002, undefined, ".")).length
+    ).toBe(2);
+
+    // filtering by a path no commit ever touched yields no commits
+    expect(
+      (
+        await getGitDiff(COMMIT_INITIAL, COMMIT_VER002, undefined, [
+          "does/not/exist",
+        ])
+      ).length
+    ).toBe(0);
+
+    // filtering only limits, never adds commits
+    const all = await getGitDiff(COMMIT_INITIAL, "HEAD");
+    const filtered = await getGitDiff(COMMIT_INITIAL, "HEAD", undefined, [
+      "src",
+      "test",
+    ]);
+    expect(filtered.length).toBeGreaterThan(0);
+    expect(filtered.length).toBeLessThanOrEqual(all.length);
+  });
+
   test("parse commit with emoji", async () => {
     const rawCommitEmojiList = [
       {


### PR DESCRIPTION
resolves https://github.com/unjs/changelogen/issues/232

adds a `--path` cli flag to only include commits touching given paths in the changelog
there is already an older PR for this https://github.com/unjs/changelogen/pull/233, but I thought I'd include some tests for it too, and I think that `path` is a more suitable name for the argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--path` CLI option to limit changelog generation to commits affecting specified repository paths.
  * Supports repeating the option to filter multiple paths, including monorepo workflows.
  * Added path filtering support to changelog configuration.

* **Documentation**
  * Updated CLI usage documentation with the new `--path` option.

* **Tests**
  * Added coverage for repository-root, existing-path, non-existent-path, and multiple path filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->