### PR TITLE
fix: format Bitbucket author emails

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -97,7 +97,7 @@ export async function generateMarkDown(
         );
         const email =
           config.hideAuthorEmail !== true && _email
-            ? formatEmail(_email, config.repo)
+            ? ` ${formatEmail(_email, config.repo)}`
             : "";
         const github = i.github
           ? ` ([@${i.github}](https://github.com/${i.github}))`

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -2,7 +2,7 @@ import { upperFirst } from "scule";
 import { convert } from "convert-gitmoji";
 import type { ResolvedChangelogConfig } from "./config";
 import type { GitCommit, Reference } from "./git";
-import { formatReference, formatCompareChanges } from "./repo";
+import { formatReference, formatCompareChanges, formatEmail } from "./repo";
 
 export async function generateMarkDown(
   commits: GitCommit[],
@@ -96,7 +96,9 @@ export async function generateMarkDown(
           (e) => !e.includes("noreply.github.com")
         );
         const email =
-          config.hideAuthorEmail !== true && _email ? ` <${_email}>` : "";
+          config.hideAuthorEmail !== true && _email
+            ? formatEmail(_email, config.repo)
+            : "";
         const github = i.github
           ? ` ([@${i.github}](https://github.com/${i.github}))`
           : "";

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -72,8 +72,8 @@ export function formatCompareChanges(
 
 export function formatEmail(email: string, repo: RepoConfig) {
   return repo.provider === "bitbucket"
-    ? ` [${email}](mailto:${email})`
-    : ` <${email}>`;
+    ? `[${email}](mailto:${email})`
+    : `<${email}>`;
 }
 
 export async function resolveRepoConfig(cwd: string) {

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -70,6 +70,12 @@ export function formatCompareChanges(
   return `[compare changes](${baseUrl(config.repo)}/${part}/${changes})`;
 }
 
+export function formatEmail(email: string, repo: RepoConfig) {
+  return repo.provider === "bitbucket"
+    ? ` [${email}](mailto:${email})`
+    : ` <${email}>`;
+}
+
 export async function resolveRepoConfig(cwd: string) {
   // Try closest package.json
   const pkg = await readPackageJSON(cwd).catch(() => {});

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -127,15 +127,15 @@ describe("repo", () => {
     test.each([
       {
         provider: "bitbucket" as const,
-        output: " [author@example.com](mailto:author@example.com)",
+        output: "[author@example.com](mailto:author@example.com)",
       },
       {
         provider: "github" as const,
-        output: " <author@example.com>",
+        output: "<author@example.com>",
       },
       {
         provider: "gitlab" as const,
-        output: " <author@example.com>",
+        output: "<author@example.com>",
       },
     ])("formats email for $provider", ({ provider, output }) => {
       expect(formatEmail("author@example.com", { provider })).toBe(output);

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { getRepoConfig } from "../src";
+import { formatEmail, getRepoConfig } from "../src";
 
 describe("repo", () => {
   describe("getRepoConfig", () => {
@@ -120,6 +120,25 @@ describe("repo", () => {
       test("should return empty RepoConfig", () => {
         expect(getRepoConfig()).toEqual({});
       });
+    });
+  });
+
+  describe("formatEmail", () => {
+    test.each([
+      {
+        provider: "bitbucket" as const,
+        output: " [author@example.com](mailto:author@example.com)",
+      },
+      {
+        provider: "github" as const,
+        output: " <author@example.com>",
+      },
+      {
+        provider: "gitlab" as const,
+        output: " <author@example.com>",
+      },
+    ])("formats email for $provider", ({ provider, output }) => {
+      expect(formatEmail("author@example.com", { provider })).toBe(output);
     });
   });
 });


### PR DESCRIPTION
Fixes #337 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contributor email addresses now use repository-specific formatting.
  * Email addresses link directly to an email client for Bitbucket repositories.
  * GitHub and GitLab email addresses retain angle-bracket formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->