### PR TITLE
fix(git): omit HEAD tag when resolving previous git tag (#292)

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -29,7 +29,11 @@ export interface GitCommit extends RawGitCommit {
 
 export async function getLastGitTag(cwd?: string) {
   try {
-    return execCommand("git describe --tags --abbrev=0", cwd)
+    const headTag = getCurrentGitTag(cwd);
+    return execCommand(
+      `git describe --tags --abbrev=0 ${headTag ? "HEAD^" : ""}`.trim(),
+      cwd
+    )
       ?.split("\n")
       .at(-1);
   } catch {

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -6,6 +6,7 @@ import {
   parseCommits,
   getRepoConfig,
   formatReference,
+  getLastGitTag,
 } from "../src";
 import { RepoConfig } from "./../src/repo";
 
@@ -19,6 +20,12 @@ describe("git", () => {
     expect((await getGitDiff(COMMIT_INITIAL, "HEAD")).length + 1).toBe(
       all.length
     );
+  });
+
+  test("getLastGitTag should return previous tag", async () => {
+    const lastTag = await getLastGitTag();
+    expect(typeof lastTag).toBe("string");
+    expect(lastTag).toMatch(/^v\d+\.\d+\.\d+/);
   });
 
   test("parse commit with emoji", async () => {


### PR DESCRIPTION
Resolves #292

### Problem
When the current `HEAD` commit is tagged (for example, right after releasing or checking out a release tag), `getLastGitTag` executes `git describe --tags --abbrev=0`, which returns the tag pointing directly at `HEAD`. As a result, running `changelogen` without an explicit `--from` resolves `config.from` and `config.to` to the exact same tag, generating an empty changelog from HEAD to HEAD.

### Solution
Check if `HEAD` points to a tag via `getCurrentGitTag(cwd)`. If `HEAD` is tagged, pass `HEAD^` to `git describe --tags --abbrev=0 HEAD^` so that `getLastGitTag` returns the previous release tag prior to `HEAD`.

### Testing
- Added a unit test in `test/git.test.ts` verifying `getLastGitTag()` returns the expected tag pattern.
- Ran full test suite (`pnpm test`), lint (`eslint`), and formatting check (`prettier`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected version tag detection when the current commit is itself tagged, ensuring the previous applicable tag is identified.

- **Tests**
  - Added coverage verifying that the reported tag follows the expected semantic version format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->